### PR TITLE
Adding extra dependencies

### DIFF
--- a/setup_cs_centos7.sh
+++ b/setup_cs_centos7.sh
@@ -23,6 +23,5 @@ curl "https://bootstrap.pypa.io/get-pip.py" | python
 pip install mysql-connector-python --allow-external mysql-connector-python requests
 pip install cloudmonkey
 
-easy_install python-paramiko
 easy_install nose
 easy_install pycrypto

--- a/setup_cs_centos7.sh
+++ b/setup_cs_centos7.sh
@@ -2,7 +2,7 @@
 
 # Prepare CentOS7 bare box to compile CloudStack and run management server
 
-yum -y install maven tomcat6 mkisofs genisoimage gcc python MySQL-python openssh-clients wget git python-ecdsa bzip2 python-setuptools mariadb-server mariadb python-devel vim nfs-utils screen
+yum -y install maven tomcat mkisofs python-paramiko jakarta-commons-daemon-jsvc jsvc ws-commons-util genisoimage gcc python MySQL-python openssh-clients wget git python-ecdsa bzip2 python-setuptools mariadb-server mariadb python-devel vim nfs-utils screen
 
 systemctl start mariadb.service
 systemctl enable mariadb.service
@@ -22,3 +22,7 @@ wget https://raw.githubusercontent.com/remibergsma/dotfiles/master/.screenrc
 curl "https://bootstrap.pypa.io/get-pip.py" | python 
 pip install mysql-connector-python --allow-external mysql-connector-python requests
 pip install cloudmonkey
+
+easy_install python-paramiko
+easy_install nose
+easy_install pycrypto


### PR DESCRIPTION
@neubauerf @remibergsma 

Could you have a look at my changes and merge this PR?

easy_install is part of the python-setuptools

The dependencies I added are needed in order to have Marvin configured and also in order to be able to build the CloudStack Agent (KVM needs it).

Cheers,
Wilder
