### PR TITLE
Enable NiciraNvp plugin in config

### DIFF
--- a/marvin/mct-zone1-kvm1-NVP.cfg
+++ b/marvin/mct-zone1-kvm1-NVP.cfg
@@ -42,6 +42,10 @@
                         },
                         {
                             "broadcastdomainrange": "ZONE",
+                            "name": "NiciraNvp"
+                        },
+                        {
+                            "broadcastdomainrange": "ZONE",
                             "name": "VpcVirtualRouter"
                         },
                         {
@@ -218,5 +222,8 @@
             "certCAPath":  "NA",
             "certPath":  "NA"
         }
-    ]
+    ],
+    "niciraNvp": {
+    	"hosts": [ "nsxcon1.cloud.lan", "nsxcon2.cloud.lan" ]
+    }
 }

--- a/marvin/mct-zone1-kvm1-NVP.cfg
+++ b/marvin/mct-zone1-kvm1-NVP.cfg
@@ -54,7 +54,7 @@
                         }
                     ],
                     "isolationmethods": [
-                             "VLAN"
+                             "STT"
                     ]
                 },
                 {


### PR DESCRIPTION
This PR adds the NiciraNvp plugin to the marvin config (for it to be loaded, changes made to deployDatacenter.py introduced in pending PR need to be merged)
PR link: https://github.com/apache/cloudstack/pull/737

The network isolation method is also changed to STT instead of VLAN.
