### PR TITLE
Wait for reboot to happen when deploying VMs

### DIFF
--- a/deploy/firstboot/centos7-cloudstack-dev.sh
+++ b/deploy/firstboot/centos7-cloudstack-dev.sh
@@ -32,9 +32,3 @@ easy_install pycrypto
 
 # Reboot
 reboot
-
-# Keep the script running unti reboot happens
-while :
-do
-  # loop infinitely
-done

--- a/deploy/firstboot/centos7-kvm.sh
+++ b/deploy/firstboot/centos7-kvm.sh
@@ -93,8 +93,3 @@ STP=yes" > /etc/sysconfig/network-scripts/ifcfg-cloudbr1
 # Reboot
 reboot
 
-# Keep the script running until the reboot happens
-while :
-do
-  # loop infinitely
-done

--- a/deploy/postboot/post_detect_reboot.sh
+++ b/deploy/postboot/post_detect_reboot.sh
@@ -7,7 +7,7 @@ echo "Note: ${NEWHOST}: Waiting for the VM to boot..."
 while ! ping -c1 ${NEWHOST} &>/dev/null; do :; done
 echo "Note: ${NEWHOST}: Installing and configuring"
 echo "Note: ${NEWHOST}: This will take some time. You may send this to the background."
-while ping -c1 ${NEWHOST} &>/dev/null; do :; done
+while ping -c5 ${NEWHOST} &>/dev/null; do :; done
 echo "Note: ${NEWHOST}: Rebooting"
 while ! ping -c1 ${NEWHOST} &>/dev/null; do :; done
 sleep 15


### PR DESCRIPTION
The `post_detect_reboot.sh` pings a VM until it can't ping it anymore. At that time it assumes that the machine rebooted. However, during the creation of the in the CS centos7 machines, there can be a temporary ping that miss (see `ping: sendmsg: Operation not permitted` in next block).

```
--- cs1.cloud.lan ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.169/0.169/0.169/0.000 ms
ping: sendmsg: Operation not permitted
PING cs1.cloud.lan (192.168.22.61) 56(84) bytes of data.

--- cs1.cloud.lan ping statistics ---
1 packets transmitted, 0 received, 100% packet loss, time 0ms
```

When this happens the script will assume that the VM is rebooting and keeps pinging it until it gets a packet back. That happens quite quickly because the VM is not even close to rebooting and the script assumes the VM is ready.

This PR adds a 5 second period to the ping that waits for the machine to be unreachable. The resulting ping looks like this:

```
PING cs1.cloud.lan (192.168.22.61) 56(84) bytes of data.
64 bytes from cs1.cloud.lan (192.168.22.61): icmp_seq=1 ttl=64 time=0.684 ms
64 bytes from cs1.cloud.lan (192.168.22.61): icmp_seq=2 ttl=64 time=0.438 ms
64 bytes from cs1.cloud.lan (192.168.22.61): icmp_seq=3 ttl=64 time=3.59 ms
64 bytes from cs1.cloud.lan (192.168.22.61): icmp_seq=4 ttl=64 time=0.253 ms
64 bytes from cs1.cloud.lan (192.168.22.61): icmp_seq=5 ttl=64 time=0.253 ms

--- cs1.cloud.lan ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 4005ms
rtt min/avg/max/mdev = 0.253/1.045/3.599/1.286 ms
```

Maybe 5 seconds is not the best option, and might need to be adjusted. For now it seems to be working.
