### PR TITLE
Rebase with current master before testing pr

### DIFF
--- a/helper_scripts/cloudstack/check-pr.sh
+++ b/helper_scripts/cloudstack/check-pr.sh
@@ -86,5 +86,13 @@ if [ $? -gt 0  ]; then
   exit 1
 fi
 
+# Rebase with current master before tests
+git fetch
+git rebase master
+if [ $? -gt 0  ]; then
+  echo "ERROR: Rebase with master failed, please ask author to rebase and force-push commits. Then try again!"
+  exit 1
+fi
+
 # Build, run and test it
 /data/shared/helper_scripts/cloudstack/build_run_deploy_test.sh -m ${marvinCfg} ${run_tests} ${skip} ${compile_threads}


### PR DESCRIPTION
This will prevent many false positives (problems that were in master at time of branching off, that have been resolved on master in the mean while). It also saves time in asking for rebasing all the time.

I believe Jenkins at Apache also does this.

Good idea?
