### PR TITLE
Restrict builds on mct slaves and run testes sequentially

### DIFF
--- a/ci/mct-ci-build-job-dsl.groovy
+++ b/ci/mct-ci-build-job-dsl.groovy
@@ -9,7 +9,9 @@ def MARVIN_TESTS_WITH_HARDWARE = [
   'component/test_routers_iptables_default_policy',
   'component/test_routers_network_ops',
   'component/test_vpc_router_nics',
-  'smoke/test_loadbalance'
+  'smoke/test_loadbalance',
+  'smoke/test_internal_lb.py',
+  'smoke/test_ssvm.py'
 ]
 
 def MARVIN_TESTS_WITHOUT_HARDWARE = [

--- a/ci/mct-ci-build-job-dsl.groovy
+++ b/ci/mct-ci-build-job-dsl.groovy
@@ -11,7 +11,8 @@ def MARVIN_TESTS_WITH_HARDWARE = [
   'component/test_vpc_router_nics',
   'smoke/test_loadbalance',
   'smoke/test_internal_lb',
-  'smoke/test_ssvm'
+  'smoke/test_ssvm',
+  'smoke/test_network'
 ]
 
 def MARVIN_TESTS_WITHOUT_HARDWARE = [
@@ -23,7 +24,8 @@ def MARVIN_TESTS_WITHOUT_HARDWARE = [
   'smoke/test_vpc_vpn',
   'smoke/test_service_offerings',
   'component/test_vpc_offerings',
-  'component/test_vpc_routers'
+  'component/test_vpc_routers',
+  'smoke/test_network'
 ]
 
 def MARVIN_CONFIG_FILE = 'mct-zone1-kvm1-kvm2.cfg'

--- a/ci/mct-ci-build-job-dsl.groovy
+++ b/ci/mct-ci-build-job-dsl.groovy
@@ -44,6 +44,7 @@ FOLDERS.each { folder_name ->
   def cleanUpInfraJobName   = "${folder_name}/mct-cleanup-infra"
 
   workflowJob(aggregatodJobName) {
+    quietPeriod(60)
     parameters {
       textParam('git_repo_url', DEFAULT_GIT_REPO_URL, 'The git repository url ')
       textParam('sha1', DEFAULT_GIT_REPO_BRANCH, 'The git branch (or commit hash)')

--- a/ci/mct-ci-build-job-dsl.groovy
+++ b/ci/mct-ci-build-job-dsl.groovy
@@ -114,7 +114,7 @@ FOLDERS.each { folder_name ->
     }
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
-      textParam('parent_job', deployInfraJobName, 'The parent job name')
+      textParam('parent_job', checkoutJobName, 'The parent job name')
       textParam('parent_job_build', '', 'The parent job build number')
       textParam('marvin_config_file', MARVIN_CONFIG_FILE, 'Marvin configuration file')
     }
@@ -133,7 +133,7 @@ FOLDERS.each { folder_name ->
     }
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
-      textParam('parent_job', deployDcJobName, 'The parent job name')
+      textParam('parent_job', checkoutJobName, 'The parent job name')
       textParam('parent_job_build', '', 'The parent job build number')
       textParam('marvin_tests_with_hw', MARVIN_TESTS_WITH_HARDWARE.join(' '), 'Marvin tests tagged as require_hardware=true')
       textParam('marvin_tests_without_hw', MARVIN_TESTS_WITHOUT_HARDWARE.join(' '), 'Marvin tests tagged as require_hardware=false')
@@ -153,7 +153,7 @@ FOLDERS.each { folder_name ->
     }
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
-      textParam('parent_job', runMarvinTestsJobName, 'The parent job name')
+      textParam('parent_job', deployInfraJobName, 'The parent job name')
       textParam('parent_job_build', '', 'The parent job build number')
       textParam('marvin_config_file', MARVIN_CONFIG_FILE, 'Marvin configuration file')
     }

--- a/ci/mct-ci-build-job-dsl.groovy
+++ b/ci/mct-ci-build-job-dsl.groovy
@@ -10,8 +10,8 @@ def MARVIN_TESTS_WITH_HARDWARE = [
   'component/test_routers_network_ops',
   'component/test_vpc_router_nics',
   'smoke/test_loadbalance',
-  'smoke/test_internal_lb.py',
-  'smoke/test_ssvm.py'
+  'smoke/test_internal_lb',
+  'smoke/test_ssvm'
 ]
 
 def MARVIN_TESTS_WITHOUT_HARDWARE = [

--- a/ci/mct-ci-build-job-dsl.groovy
+++ b/ci/mct-ci-build-job-dsl.groovy
@@ -92,7 +92,7 @@ FOLDERS.each { folder_name ->
     }
     definition {
       cps {
-        script(readFileFromWorkspace('ci/mct-workflow-cleanup-infra-job.groovy'))
+        script(readFileFromWorkspace('ci/mct-workflow-deploy-infra-job.groovy'))
       }
     }
   }

--- a/ci/mct-ci-build-job-dsl.groovy
+++ b/ci/mct-ci-build-job-dsl.groovy
@@ -97,7 +97,7 @@ FOLDERS.each { folder_name ->
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
       textParam('parent_job', checkoutJobName, 'The parent job name')
-      textParam('parent_job_build', '', 'The parent job build number')
+      textParam('parent_job_build', 'last_completed', 'The parent job build number')
       textParam('marvin_config_file', MARVIN_CONFIG_FILE, 'Marvin configuration file')
     }
     definition {
@@ -115,7 +115,7 @@ FOLDERS.each { folder_name ->
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
       textParam('parent_job', checkoutJobName, 'The parent job name')
-      textParam('parent_job_build', '', 'The parent job build number')
+      textParam('parent_job_build', 'last_completed', 'The parent job build number')
       textParam('marvin_config_file', MARVIN_CONFIG_FILE, 'Marvin configuration file')
     }
     definition {
@@ -134,7 +134,7 @@ FOLDERS.each { folder_name ->
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
       textParam('parent_job', checkoutJobName, 'The parent job name')
-      textParam('parent_job_build', '', 'The parent job build number')
+      textParam('parent_job_build', 'last_completed', 'The parent job build number')
       textParam('marvin_tests_with_hw', MARVIN_TESTS_WITH_HARDWARE.join(' '), 'Marvin tests tagged as require_hardware=true')
       textParam('marvin_tests_without_hw', MARVIN_TESTS_WITHOUT_HARDWARE.join(' '), 'Marvin tests tagged as require_hardware=false')
       textParam('marvin_config_file', MARVIN_CONFIG_FILE, 'Marvin configuration file')
@@ -154,7 +154,7 @@ FOLDERS.each { folder_name ->
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
       textParam('parent_job', deployInfraJobName, 'The parent job name')
-      textParam('parent_job_build', '', 'The parent job build number')
+      textParam('parent_job_build', 'last_completed', 'The parent job build number')
       textParam('marvin_config_file', MARVIN_CONFIG_FILE, 'Marvin configuration file')
     }
     definition {

--- a/ci/mct-ci-build-job-dsl.groovy
+++ b/ci/mct-ci-build-job-dsl.groovy
@@ -33,8 +33,6 @@ def FOLDERS = [
   'mccloud-dev'
 ]
 
-
-
 FOLDERS.each { folder_name ->
   folder(folder_name)
 
@@ -47,6 +45,10 @@ FOLDERS.each { folder_name ->
 
   workflowJob(aggregatodJobName) {
     quietPeriod(60)
+    logRotator {
+      numToKeep(5)
+      artifactNumToKeep(5)
+    }
     parameters {
       textParam('git_repo_url', DEFAULT_GIT_REPO_URL, 'The git repository url ')
       textParam('sha1', DEFAULT_GIT_REPO_BRANCH, 'The git branch (or commit hash)')
@@ -67,6 +69,10 @@ FOLDERS.each { folder_name ->
   }
 
   workflowJob(checkoutJobName) {
+    logRotator {
+      numToKeep(5)
+      artifactNumToKeep(5)
+    }
     parameters {
       textParam('git_repo_url', DEFAULT_GIT_REPO_URL, 'The git repository url ')
       textParam('sha1', DEFAULT_GIT_REPO_BRANCH, 'The git branch (or commit hash)')
@@ -84,6 +90,10 @@ FOLDERS.each { folder_name ->
   }
 
   workflowJob(deployInfraJobName) {
+    logRotator {
+      numToKeep(5)
+      artifactNumToKeep(5)
+    }
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
       textParam('parent_job', checkoutJobName, 'The parent job name')
@@ -98,6 +108,10 @@ FOLDERS.each { folder_name ->
   }
 
   workflowJob(deployDcJobName) {
+    logRotator {
+      numToKeep(5)
+      artifactNumToKeep(5)
+    }
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
       textParam('parent_job', deployInfraJobName, 'The parent job name')
@@ -113,6 +127,10 @@ FOLDERS.each { folder_name ->
 
 
   workflowJob(runMarvinTestsJobName) {
+    logRotator {
+      numToKeep(5)
+      artifactNumToKeep(5)
+    }
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
       textParam('parent_job', deployDcJobName, 'The parent job name')
@@ -129,6 +147,10 @@ FOLDERS.each { folder_name ->
   }
 
   workflowJob(cleanUpInfraJobName) {
+    logRotator {
+      numToKeep(5)
+      artifactNumToKeep(5)
+    }
     parameters {
       textParam('executor', EXECUTOR, 'The executor label')
       textParam('parent_job', runMarvinTestsJobName, 'The parent job name')
@@ -142,6 +164,3 @@ FOLDERS.each { folder_name ->
     }
   }
 }
-
-
-

--- a/ci/mct-workflow-aggregator.groovy
+++ b/ci/mct-workflow-aggregator.groovy
@@ -27,6 +27,7 @@ print "==> Chekout Build Number = ${checkoutJobBuildNumber}"
 // NOTE: This only works if we set a quiet period for the job, otherwise two jobs might be scheduled too fast
 // and the same executoer might be picked for both.
 def executor = getAvailableNode('executor-mct')
+print "==> Elected MCT executor ${executor} for this build"
 
 def mctDeployInfraParameters =[
   new StringParameterValue('executor', executor, 'Executor'),

--- a/ci/mct-workflow-aggregator.groovy
+++ b/ci/mct-workflow-aggregator.groovy
@@ -44,8 +44,8 @@ print "==> Deploy Infra Build Number = ${deployInfraJobBuildNumber}"
 
 def mctDeployDcParameters =[
   new StringParameterValue('executor', executor, 'Executor'),
-  new StringParameterValue('parent_job', deployInfraJobName, 'Parent Job Name'),
-  new StringParameterValue('parent_job_build', deployInfraJobBuildNumber, 'Parent Job Build Number'),
+  new StringParameterValue('parent_job', checkoutJobName, 'Parent Job Name'),
+  new StringParameterValue('parent_job_build', checkoutJobBuildNumber, 'Parent Job Build Number'),
   new StringParameterValue('marvin_config_file', marvinConfigFile, 'Marvin Configuration File')
 ]
 
@@ -57,29 +57,38 @@ print "==> Deploy DC Build Number = ${deployDcJobBuildNumber}"
 
 def mctRunMarvinTestsParameters = [
   new StringParameterValue('executor', executor, 'Executor'),
-  new StringParameterValue('parent_job', deployDcJobName, 'Parent Job Name'),
-  new StringParameterValue('parent_job_build', deployDcJobBuildNumber, 'Parent Job Build Number'),
+  new StringParameterValue('parent_job', checkoutJobName, 'Parent Job Name'),
+  new StringParameterValue('parent_job_build', checkoutJobBuildNumber, 'Parent Job Build Number'),
   new StringParameterValue('marvin_tests_with_hw', marvinTestsWithHw.join(' '), 'Marvin tests that require Hardware'),
   new StringParameterValue('marvin_tests_without_hw', marvinTestsWithoutHw.join(' '), 'Marvin tests that do not require Hardware'),
   new StringParameterValue('marvin_config_file', marvinConfigFile, 'Marvin Configuration File')
 ]
 
-def runMarvinTestsJobName  = './mct-run-marvin-tests'
-def runMarvinTestsJobBuild = build job: runMarvinTestsJobName, parameters: mctRunMarvinTestsParameters
+try {
+  def runMarvinTestsJobName  = './mct-run-marvin-tests'
+  def runMarvinTestsJobBuild = build job: runMarvinTestsJobName, parameters: mctRunMarvinTestsParameters
+}
+catch(e) {
+  echo "==> Marvin tests build was not successful"
+}
+finally {
+  def runMarvinTestsJobBuildNumber = runMarvinTestsJobBuild.getNumber() as String
+  print "==> Run Marvin Tests Build Number = ${runMarvinTestsJobBuildNumber}"
 
-def runMarvinTestsJobBuildNumber = runMarvinTestsJobBuild.getNumber() as String
-print "==> Run Marvin Tests Build Number = ${runMarvinTestsJobBuildNumber}"
+  def mctCleanUpInfraParameters = [
+    new StringParameterValue('executor', executor, 'Executor'),
+    new StringParameterValue('parent_job', deployDcJobName, 'Parent Job Name'),
+    new StringParameterValue('parent_job_build', deployDcJobBuildNumber, 'Parent Job Build Number'),
+    new StringParameterValue('marvin_config_file', marvinConfigFile, 'Marvin Configuration File')
+  ]
 
-def mctCleanUpInfraParameters = [
-  new StringParameterValue('executor', executor, 'Executor'),
-  new StringParameterValue('parent_job', runMarvinTestsJobName, 'Parent Job Name'),
-  new StringParameterValue('parent_job_build', runMarvinTestsJobBuildNumber, 'Parent Job Build Number'),
-  new StringParameterValue('marvin_config_file', marvinConfigFile, 'Marvin Configuration File')
-]
+  def cleanUpInfraJobBuild = build job: './mct-cleanup-infra', parameters: mctCleanUpInfraParameters
 
-def cleanUpInfraJobBuild = build job: './mct-cleanup-infra', parameters: mctCleanUpInfraParameters
+  print "==> Clean Up Infra Build Number = ${cleanUpInfraJobBuild.getNumber()}"
+}
 
-print "==> Clean Up Infra Build Number = ${cleanUpInfraJobBuild.getNumber()}"
+
+
 
 //def credentials = findCredentials({ c -> c.id  == '298a5b23-7bfc-4b68-82aa-ca44465b157d' })
 def findCredentials(matcher) {

--- a/ci/mct-workflow-checkout-and-build-job.groovy
+++ b/ci/mct-workflow-checkout-and-build-job.groovy
@@ -42,6 +42,8 @@ node('executor') {
   archive DB_SCRIPTS.join(', ')
   archive TEMPLATE_SCRIPTS.join(', ')
   archive MARVIN_SCRIPTS.join(', ')
+
+  sh 'rm -rf dist'
 }
 
 // ----------------

--- a/ci/mct-workflow-checkout-and-build-job.groovy
+++ b/ci/mct-workflow-checkout-and-build-job.groovy
@@ -26,7 +26,9 @@ def MARVIN_SCRIPTS = [
 
 node('executor') {
   checkout scm: [$class: 'GitSCM', branches:          [[name: gitBranch]],
-                                   userRemoteConfigs: [[url:  gitRepoUrl, credentialsId: gitRepoCredentials]]]
+                                   userRemoteConfigs: [[url:  gitRepoUrl,
+                                                        credentialsId: gitRepoCredentials,
+                                                        refspec: '+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*']]]
 
   def projectVersion = version()
 

--- a/ci/mct-workflow-cleanup-infra-job.groovy
+++ b/ci/mct-workflow-cleanup-infra-job.groovy
@@ -16,6 +16,14 @@ node(nodeExecutor) {
   scp('root@cs1:~tomcat/api.log*', '.')
   archive 'vmops.log*, api.log*'
 
+  sh 'mkdir kvm1-agent-logs'
+  scp('root@kvm1:/var/log/cloudstack/agent/agent.log*', 'kvm1-agent-logs/')
+  archive 'kvm1-agent-logs/'
+
+  sh 'mkdir kvm2-agent-logs'
+  scp('root@kvm2:/var/log/cloudstack/agent/agent.log*', 'kvm2-agent-logs/')
+  archive 'kvm2-agent-logs/'
+
   writeFile file: 'dumpDb.sh', text: 'mysqldump -u root cloud > dirty-db-dump.sql'
   scp('dumpDb.sh', 'root@cs1:./')
   ssh('root@cs1', 'chmod +x dumpDb.sh; ./dumpDb.sh')

--- a/ci/mct-workflow-cleanup-infra-job.groovy
+++ b/ci/mct-workflow-cleanup-infra-job.groovy
@@ -1,11 +1,12 @@
 import hudson.plugins.copyartifact.SpecificBuildSelector
 
 // Job Parameters
+def nodeExecutor         = executor
 def parentJob            = parent_job
 def parentJobBuild       = parent_job_build
 def marvinConfigFile     = marvin_config_file
 
-node('executor-mct') {
+node(nodeExecutor) {
   copyFilesFromParentJob(parentJob, parentJobBuild, [marvinConfigFile])
 
   scp('root@cs1:~tomcat/vmops.log', '.')

--- a/ci/mct-workflow-cleanup-infra-job.groovy
+++ b/ci/mct-workflow-cleanup-infra-job.groovy
@@ -7,7 +7,9 @@ def parentJobBuild       = parent_job_build
 def marvinConfigFile     = marvin_config_file
 
 node(nodeExecutor) {
-  copyFilesFromParentJob(parentJob, parentJobBuild, [marvinConfigFile, 'fresh-db-dump.sql'])
+  copyFilesFromParentJob(parentJob, parentJobBuild, ['fresh-db-dump.sql'])
+
+  sh  "cp /data/shared/marvin/${marvinConfigFile} ./"
 
   scp('root@cs1:~tomcat/vmops.log*', '.')
   scp('root@cs1:~tomcat/api.log*', '.')

--- a/ci/mct-workflow-cleanup-infra-job.groovy
+++ b/ci/mct-workflow-cleanup-infra-job.groovy
@@ -9,9 +9,9 @@ def marvinConfigFile     = marvin_config_file
 node(nodeExecutor) {
   copyFilesFromParentJob(parentJob, parentJobBuild, [marvinConfigFile])
 
-  scp('root@cs1:~tomcat/vmops.log', '.')
-  scp('root@cs1:~tomcat/api.log', '.')
-  archive 'vmops.log, api.log'
+  scp('root@cs1:~tomcat/vmops.log*', '.')
+  scp('root@cs1:~tomcat/api.log*', '.')
+  archive 'vmops.log*, api.log*'
   // TODO: replace hardcoded box names
   sh '/data/vm-easy-deploy/remove_vm.sh -f cs1'
   sh '/data/vm-easy-deploy/remove_vm.sh -f kvm1'

--- a/ci/mct-workflow-cleanup-infra-job.groovy
+++ b/ci/mct-workflow-cleanup-infra-job.groovy
@@ -7,11 +7,20 @@ def parentJobBuild       = parent_job_build
 def marvinConfigFile     = marvin_config_file
 
 node(nodeExecutor) {
-  copyFilesFromParentJob(parentJob, parentJobBuild, [marvinConfigFile])
+  copyFilesFromParentJob(parentJob, parentJobBuild, [marvinConfigFile, 'fresh-db-dump.sql'])
 
   scp('root@cs1:~tomcat/vmops.log*', '.')
   scp('root@cs1:~tomcat/api.log*', '.')
   archive 'vmops.log*, api.log*'
+
+  writeFile file: 'dumpDb.sh', text: 'mysqldump -u root cloud > dirty-db-dump.sql'
+  scp('dumpDb.sh', 'root@cs1:./')
+  ssh('root@cs1', 'chmod +x dumpDb.sh; ./dumpDb.sh')
+  archive 'dirty-db-dump.sql'
+
+  sh 'diff fresh-db-dump.sql dirty-db-dump.sql > db_diff.txt'
+  archive 'db_diff.txt'
+
   // TODO: replace hardcoded box names
   sh '/data/vm-easy-deploy/remove_vm.sh -f cs1'
   sh '/data/vm-easy-deploy/remove_vm.sh -f kvm1'
@@ -29,4 +38,13 @@ def copyFilesFromParentJob(parentJob, parentJobBuild, filesToCopy) {
 
 def scp(source, target) {
   sh "scp -i ~/.ssh/mccd-jenkins.pem -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q -r ${source} ${target}"
+}
+
+def ssh(target, command) {
+  sh "ssh -i ~/.ssh/mccd-jenkins.pem -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q ${target} \"${command}\""
+}
+
+def mysqlScript(host, user, pass, db, script) {
+  def passOption = pass !=  '' ? "-p${pass}" : ''
+  sh "mysql -h${host} -u ${user} ${passOption} ${db} < ${script}"
 }

--- a/ci/mct-workflow-cleanup-infra-job.groovy
+++ b/ci/mct-workflow-cleanup-infra-job.groovy
@@ -1,4 +1,5 @@
 import hudson.plugins.copyartifact.SpecificBuildSelector
+import hudson.plugins.copyartifact.LastCompletedBuildSelector
 
 // Job Parameters
 def nodeExecutor         = executor
@@ -35,7 +36,15 @@ node(nodeExecutor) {
 
 // TODO: move to library
 def copyFilesFromParentJob(parentJob, parentJobBuild, filesToCopy) {
-  step ([$class: 'CopyArtifact',  projectName: parentJob,  selector: new SpecificBuildSelector(parentJobBuild), filter: filesToCopy.join(', ')]);
+  def buildSelector = { build ->
+    if(build == null || build.isEmpty() || build.equals('last_completed')) {
+      new LastCompletedBuildSelector()
+    } else {
+      new SpecificBuildSelector(build)
+    }
+  }
+
+  step ([$class: 'CopyArtifact',  projectName: parentJob, selector: buildSelector(parentJobBuild), filter: filesToCopy.join(', ')]);
 }
 
 def scp(source, target) {

--- a/ci/mct-workflow-deploy-data-center-job.groovy
+++ b/ci/mct-workflow-deploy-data-center-job.groovy
@@ -1,6 +1,7 @@
 import hudson.plugins.copyartifact.SpecificBuildSelector
 
 // Job Parameters
+def nodeExecutor     = executor
 def parentJob        = parent_job
 def parentJobBuild   = parent_job_build
 def marvinConfigFile = marvin_config_file
@@ -12,7 +13,7 @@ def MARVIN_SCRIPTS = [
   'tools/travis/xunit-reader.py'
 ]
 
-node('executor') {
+node(nodeExecutor) {
   def filesToCopy = [marvinConfigFile] + MARVIN_DIST_FILE + MARVIN_SCRIPTS
   copyFilesFromParentJob(parentJob, parentJobBuild, filesToCopy)
 

--- a/ci/mct-workflow-deploy-data-center-job.groovy
+++ b/ci/mct-workflow-deploy-data-center-job.groovy
@@ -1,4 +1,5 @@
 import hudson.plugins.copyartifact.SpecificBuildSelector
+import hudson.plugins.copyartifact.LastCompletedBuildSelector
 
 // Job Parameters
 def nodeExecutor     = executor
@@ -29,7 +30,15 @@ node(nodeExecutor) {
 
 // TODO: move to library
 def copyFilesFromParentJob(parentJob, parentJobBuild, filesToCopy) {
-  step ([$class: 'CopyArtifact',  projectName: parentJob,  selector: new SpecificBuildSelector(parentJobBuild), filter: filesToCopy.join(', ')]);
+  def buildSelector = { build ->
+    if(build == null || build.isEmpty() || build.equals('last_completed')) {
+      new LastCompletedBuildSelector()
+    } else {
+      new SpecificBuildSelector(build)
+    }
+  }
+
+  step ([$class: 'CopyArtifact',  projectName: parentJob, selector: buildSelector(parentJobBuild), filter: filesToCopy.join(', ')]);
 }
 
 def updateManagementServerIp(configFile, vmIp) {

--- a/ci/mct-workflow-deploy-infra-job.groovy
+++ b/ci/mct-workflow-deploy-infra-job.groovy
@@ -1,4 +1,5 @@
 import hudson.plugins.copyartifact.SpecificBuildSelector
+import hudson.plugins.copyartifact.LastCompletedBuildSelector
 
 // Job Parameters
 def nodeExecutor     = executor
@@ -61,7 +62,15 @@ node(nodeExecutor) {
 
 // TODO: move to library
 def copyFilesFromParentJob(parentJob, parentJobBuild, filesToCopy) {
-  step ([$class: 'CopyArtifact',  projectName: parentJob,  selector: new SpecificBuildSelector(parentJobBuild), filter: filesToCopy.join(', ')]);
+  def buildSelector = { build ->
+    if(build == null || build.isEmpty() || build.equals('last_completed')) {
+      new LastCompletedBuildSelector()
+    } else {
+      new SpecificBuildSelector(build)
+    }
+  }
+
+  step ([$class: 'CopyArtifact',  projectName: parentJob, selector: buildSelector(parentJobBuild), filter: filesToCopy.join(', ')]);
 }
 
 def deployWar() {

--- a/ci/mct-workflow-deploy-infra-job.groovy
+++ b/ci/mct-workflow-deploy-infra-job.groovy
@@ -112,7 +112,11 @@ def deployDb() {
   ]
   writeFile file: 'extraDbConfig.sql', text: extraDbConfig.join('\n')
   mysqlScript('cs1', 'cloud', 'cloud', 'cloud', 'extraDbConfig.sql')
-  sh 'rm -f grant-remote-access.sql extraDbConfig.sql'
+  writeFile file: 'dumpDb.sh', text: 'mysqldump -u root cloud > fresh-db-dump.sql'
+  scp('dumpDb.sh', 'root@cs1:./')
+  ssh('root@cs1', 'chmod +x dumpDb.sh; ./dumpDb.sh')
+  archive 'fresh-db-dump.sql'
+  sh 'rm -f grant-remote-access.sql extraDbConfig.sql fresh-db-dump.sql'
   echo '==> DB deployed'
 }
 

--- a/ci/mct-workflow-deploy-infra-job.groovy
+++ b/ci/mct-workflow-deploy-infra-job.groovy
@@ -52,8 +52,6 @@ node(nodeExecutor) {
     deployRpmsInParallel(HOSTS, nodeExecutor, parentJob, parentJobBuild, ['dist/rpmbuild/RPMS/x86_64/'])
   }, failFast: true
 
-  archive MARVIN_SCRIPTS.join(', ')
-  archive BUILD_ARTEFACTS.join(', ')
   archive marvinConfigFile
 }
 
@@ -112,11 +110,13 @@ def deployDb() {
   ]
   writeFile file: 'extraDbConfig.sql', text: extraDbConfig.join('\n')
   mysqlScript('cs1', 'cloud', 'cloud', 'cloud', 'extraDbConfig.sql')
+
   writeFile file: 'dumpDb.sh', text: 'mysqldump -u root cloud > fresh-db-dump.sql'
   scp('dumpDb.sh', 'root@cs1:./')
   ssh('root@cs1', 'chmod +x dumpDb.sh; ./dumpDb.sh')
   archive 'fresh-db-dump.sql'
   sh 'rm -f grant-remote-access.sql extraDbConfig.sql fresh-db-dump.sql'
+
   echo '==> DB deployed'
 }
 

--- a/ci/mct-workflow-run-marvin-tests-job.groovy
+++ b/ci/mct-workflow-run-marvin-tests-job.groovy
@@ -117,16 +117,19 @@ def runMultipleMarvinTests(tests, configFile, requireHardware, nodeExecutor) {
     unstash 'marvin'
     setupPython {
       installMarvin('tools/marvin/dist/Marvin-*.tar.gz')
+      def testsSuffix = "required_hardware-${requireHardware}"
+      def noseTestsReportFile = "nosetests-${testsSuffix}.xml"
+      def marvinLogsDir = "MarvinLogs-${testsSuffix}"
       try {
-        sh "nosetests --with-xunit --with-marvin --marvin-config=${configFile} -s -a tags=advanced,required_hardware=${requireHardware} ${fullPathTests.join(' ')}"
+        sh "nosetests --with-xunit --xunit-file=${noseTestsReportFile} --with-marvin --marvin-config=${configFile} -s -a tags=advanced,required_hardware=${requireHardware} ${fullPathTests.join(' ')}"
       } catch(e) {
         echo "Test run was not successful"
       }
-      archive 'nosetests.xml'
+      archive noseTestsReportFile
 
-      sh "mkdir -p MarvinLogs/"
-      sh "cp -rf /tmp/MarvinLogs/* MarvinLogs/"
-      archive 'MarvinLogs/'
+      sh "mkdir -p ${marvinLogsDir}"
+      sh "cp -rf /tmp/MarvinLogs/* ${marvinLogsDir}/"
+      archive "${marvinLogsDir}/"
     }
   }
 }

--- a/ci/mct-workflow-run-marvin-tests-job.groovy
+++ b/ci/mct-workflow-run-marvin-tests-job.groovy
@@ -1,4 +1,5 @@
 import hudson.plugins.copyartifact.SpecificBuildSelector
+import hudson.plugins.copyartifact.LastCompletedBuildSelector
 
 // Job Parameters
 def nodeExecutor         = executor
@@ -35,7 +36,15 @@ node('executor') {
 
 // TODO: move to library
 def copyFilesFromParentJob(parentJob, parentJobBuild, filesToCopy) {
-  step ([$class: 'CopyArtifact',  projectName: parentJob,  selector: new SpecificBuildSelector(parentJobBuild), filter: filesToCopy.join(', ')]);
+  def buildSelector = { build ->
+    if(build == null || build.isEmpty() || build.equals('last_completed')) {
+      new LastCompletedBuildSelector()
+    } else {
+      new SpecificBuildSelector(build)
+    }
+  }
+
+  step ([$class: 'CopyArtifact',  projectName: parentJob, selector: buildSelector(parentJobBuild), filter: filesToCopy.join(', ')]);
 }
 
 def updateManagementServerIp(configFile, vmIp) {

--- a/ci/mct-workflow-run-marvin-tests-job.groovy
+++ b/ci/mct-workflow-run-marvin-tests-job.groovy
@@ -18,9 +18,6 @@ node('executor') {
   def filesToCopy = MARVIN_DIST_FILE + MARVIN_SCRIPTS
   copyFilesFromParentJob(parentJob, parentJobBuild, filesToCopy)
 
-  sh  "cp /data/shared/marvin/${marvinConfigFile} ./"
-  updateManagementServerIp(marvinConfigFile, 'cs1')
-
   stash name: 'marvin', includes: (filesToCopy + [marvinConfigFile]).join(', ')
 
   runMultipleMarvinTests(marvinTestsWithHw, marvinConfigFile, true, nodeExecutor)
@@ -81,6 +78,10 @@ def runMarvinTestsInParallel(marvinConfigFile, marvinTests, requireHardware, nod
 def runMarvinTest(testPath, configFile, requireHardware, nodeExecutor) {
   node(nodeExecutor) {
     sh 'rm -rf ./*'
+
+    sh  "cp /data/shared/marvin/${marvinConfigFile} ./"
+    updateManagementServerIp(marvinConfigFile, 'cs1')
+
     unstash 'marvin'
     setupPython {
       installMarvin('tools/marvin/dist/Marvin-*.tar.gz')
@@ -109,10 +110,13 @@ def runMultipleMarvinTests(tests, configFile, requireHardware, nodeExecutor) {
   node(nodeExecutor) {
     sh 'rm -rf /tmp/MarvinLogs'
     sh 'rm -rf ./*'
+
+    sh  "cp /data/shared/marvin/${configFile} ./"
+    updateManagementServerIp(configFile, 'cs1')
+
     unstash 'marvin'
     setupPython {
       installMarvin('tools/marvin/dist/Marvin-*.tar.gz')
-      sh 'mkdir -p integration-test-results/smoke/misc integration-test-results/component'
       try {
         sh "nosetests --with-xunit --with-marvin --marvin-config=${configFile} -s -a tags=advanced,required_hardware=${requireHardware} ${fullPathTests.join(' ')}"
       } catch(e) {

--- a/ci/mct-workflow-run-marvin-tests-job.groovy
+++ b/ci/mct-workflow-run-marvin-tests-job.groovy
@@ -15,7 +15,8 @@ def MARVIN_SCRIPTS = [
   'tools/travis/xunit-reader.py'
 ]
 
-node(nodeExecutor) {
+// each test will grab a node(nodeExecutor)
+node('executor') {
   def filesToCopy = MARVIN_DIST_FILE + MARVIN_SCRIPTS + [marvinConfigFile]
   copyFilesFromParentJob(parentJob, parentJobBuild, filesToCopy)
   archive filesToCopy.join(', ')

--- a/ci/mct-workflow-run-marvin-tests-job.groovy
+++ b/ci/mct-workflow-run-marvin-tests-job.groovy
@@ -10,10 +10,7 @@ def marvinConfigFile     = marvin_config_file
 
 def MARVIN_DIST_FILE = [ 'tools/marvin/dist/Marvin-*.tar.gz' ]
 
-def MARVIN_SCRIPTS = [
-  'test/integration/',
-  'tools/travis/xunit-reader.py'
-]
+def MARVIN_SCRIPTS = [ 'test/integration/' ]
 
 // each test will grab a node(nodeExecutor)
 node('executor') {
@@ -30,13 +27,7 @@ node('executor') {
   }
 
   unarchive mapping: ['integration-test-results/': '.']
-  try {
-    sh 'python tools/travis/xunit-reader.py integration-test-results/'
-  } catch(all) {
-    echo 'Need to fix tools/travis/xunit-reader.py to not exit != 0'
-  }finally {
-    step([$class: 'JUnitResultArchiver', testResults: 'integration-test-results/**/test_*.xml'])
-  }
+  step([$class: 'JUnitResultArchiver', testResults: 'integration-test-results/**/test_*.xml'])
 }
 
 // ----------------

--- a/ci/mct-workflow-run-marvin-tests-job.groovy
+++ b/ci/mct-workflow-run-marvin-tests-job.groovy
@@ -77,8 +77,9 @@ def runMarvinTest(testPath, configFile, requireHardware, nodeExecutor) {
       } catch(e) {
         echo "Test ${testPath} was not successful"
       }
-      sh 'cp -rf /tmp/MarvinLogs .'
-      archive 'MarvinLogs'
+      sh "mkdir -p MarvinLogs/${testPath}"
+      sh "cp -rf /tmp/MarvinLogs/* MarvinLogs/${testPath}/"
+      archive 'MarvinLogs/'
       archive 'integration-test-results/'
     }
   }


### PR DESCRIPTION
MCT slaves share the same IP space, therefore we need to make sure a particular build is restricted to a particular slave. That is, infra deploy, DC deploy, marvin tests and clean up have to happen in the same slave.

In addition, running tests in parallel creates unpredictable results, because tests start failing in ways that do not happen when run sequentially. Therefore tests are no run sequentially, which significantly increases build time (~5 hours), but assures predictability.

Many other improvements to CI scripts:
- Added more tests
- Archiving more logs, management server and agents
- Restrict disk space used by builds, by discarding old builds, and removing `dist` directory which is usually big
- Pull in PR branches from git
- Create DB diff to compare freshly created DB with DB after running all Marvin tests
