### PR TITLE
use the improved script to detect ready templates

### DIFF
--- a/helper_scripts/cloudstack/build_run_deploy_test.sh
+++ b/helper_scripts/cloudstack/build_run_deploy_test.sh
@@ -351,7 +351,7 @@ fi
 # Wait until templates are ready
 date
 echo "Checking template status.."
-bash -x /data/shared/helper_scripts/cloudstack/wait_template_ready.sh
+python /data/shared/helper_scripts/cloudstack/wait_template_ready.py
 date
 
 # Run the tests


### PR DESCRIPTION
This will use the new script when running `build_run_deploy_test.sh`
