### PR TITLE
Clean left-over logs from previous runs, if any

### DIFF
--- a/helper_scripts/cloudstack/build_run_deploy_test.sh
+++ b/helper_scripts/cloudstack/build_run_deploy_test.sh
@@ -340,6 +340,9 @@ date
 bash -x ./scripts/storage/secondary/cloud-install-sys-tmplt -m ${secondarystorage} -f ${systemtemplate} -h ${hypervisor} -o localhost -r root -e ${imagetype} -F
 date
 
+echo "Deleting old Marvin logs, if any"
+rm -rf /tmp/MarvinLogs
+
 echo "Deploy data center.."
 python /data/git/$HOSTNAME/cloudstack/tools/marvin/marvin/deployDataCenter.py -i ${marvinCfg}
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
When rerunning a deployment or test on the same cs box, I want the old logs to be cleared to prevent confusion. Deploying a new cs box is not always needed.
