### PR TITLE
Support pre and post deploy actions for clouds and add NSX cloud post deploy

### DIFF
--- a/deploy/cloud/nsx_cluster.conf
+++ b/deploy/cloud/nsx_cluster.conf
@@ -1,5 +1,5 @@
 [cloud]
 cloud_name = nsx_cluster
-deploy_roles = nsx-manager, nsx-controller, nsx-service-node
+deploy_roles = nsx-manager, nsx-controller, nsx-service-node, kvm_ovs
 pre_deploy =
 post_deploy =

--- a/deploy/cloud/nsx_cluster.conf
+++ b/deploy/cloud/nsx_cluster.conf
@@ -2,4 +2,4 @@
 cloud_name = nsx_cluster
 deploy_roles = nsx-manager, nsx-controller, nsx-service-node, kvm_ovs
 pre_deploy =
-post_deploy =
+post_deploy = nsx_cluster.sh

--- a/deploy/config
+++ b/deploy/config
@@ -8,5 +8,7 @@ offering_dir = offering/
 hardware_dir = hardware/
 firstboot_dir = firstboot/
 postboot_dir = postboot/
+pre_deploy_dir = pre_deploy/
+post_deploy_dir = post_deploy/
 role_dir = role/
 cloud_dir = cloud/

--- a/deploy/kvm_local_deploy.py
+++ b/deploy/kvm_local_deploy.py
@@ -385,6 +385,36 @@ class kvm_local_deploy:
             return False
         return return_code
 
+    # Exectute actions before/after deploying cloud roles
+    def cloud_deploy_action(self, cloud_name, cloud_dict, phase, extra_arguments = None):
+        action = phase + '_deploy'
+        script_for_action = cloud_dict[action]
+        if self.is_defined(script_for_action):
+            try:
+                command = self.config_data['base_dir'] + "/" + self.config_data[action + '_dir'] + script_for_action
+                if extra_arguments is not None:
+                    command += " " + (" ".join(extra_arguments))
+                print "Note: " + cloud_name + ": Running " + action + " script: " + command
+                return_code = subprocess.call(command, shell=True)
+            except:
+                print "ERROR: " + cloud_name  + ": " + action + " script failed."
+                return False
+        else:
+            return_code = 0
+            print "WARNING: " + cloud_name  + ": No " + action + " script defined."
+        return return_code
+
+    def is_defined(self, string):
+        return bool(string and string.strip())
+
+    # Exectute actions before deploying cloud roles
+    def pre_deploy_action(self, cloud_name, cloud_data):
+        self.cloud_deploy_action(cloud_name, cloud_data, 'pre')
+
+    # Exectute actions before deploying cloud roles
+    def post_deploy_action(self, cloud_name, cloud_data, vm_names):
+        self.cloud_deploy_action(cloud_name, cloud_data, 'post', vm_names)
+
     # Get domain object from libvirt
     def get_domain(self, vm_name):
         return self.conn.lookupByName(vm_name)
@@ -446,8 +476,8 @@ class kvm_local_deploy:
             # Exec postboot action
             self.postboot_action(role_name, vm_name)
         except:
-            return False
-        return True
+            return None
+        return vm_name
 
     # Generate a name for the VM
     def generate_vm_name(self, role_name, digit=''):
@@ -474,14 +504,44 @@ class kvm_local_deploy:
 
     # Deploy a set of roles
     def deploy_cloud(self, cloud_name):
-        # Read config file, for each role deploy_role
-        cloud_data = self.get_cloud(cloud_name)
-        roles = cloud_data['deploy_roles'].split(',')
+        try:
+            # Get cloud
+            cloud_data = self.get_cloud(cloud_name)
+            # Exec pre_deploy action
+            self.pre_deploy_action(cloud_name, cloud_data)
+            # Deploy Cloud Roles
+            vm_names = self.deploy_cloud_roles(cloud_data['deploy_roles'].split(','))
+            sort_function = self.sort_function_for_cloud(cloud_name)
+            # Exec post_deploy action
+            self.post_deploy_action(cloud_name, cloud_data, sorted(vm_names, key=sort_function))
+        except:
+            return False
+        return True
+
+    def sort_function_for_cloud(self, cloud_name):
+        if cloud_name == "nsx_cluster":
+            return self.sort_nsx_vm_name
+        else:
+            # id function returns it's argument: id(1) = 1
+            return id
+
+    # Helper for sorting NSX cluster VMs in the way post_deploy script expects them
+    def sort_nsx_vm_name(self, vm_name):
+        if 'mgr' in vm_name:
+            return 1
+        elif 'con':
+            return 2
+        elif 'svc':
+            return 3
+        else:
+            return 4
+
+    def deploy_cloud_roles(self, roles):
         pool = ThreadPool(4)
         results = pool.map(self.deploy_role, roles)
         pool.close()
         pool.join()
-        return True
+        return results
 
     # Load the json file
     def load_marvin_json(self):
@@ -593,7 +653,7 @@ if len(deploy_role) > 0:
     if not d.role_exists(deploy_role):
         print "Error: the role does not exist."
         sys.exit(1)
-    if not d.deploy_role(deploy_role, digit):
+    if d.deploy_role(deploy_role, digit) is None:
         sys.exit(1)
     sys.exit(0)
 
@@ -607,6 +667,6 @@ if len(deploy_vm) > 0:
 
     # Create
     print "Note: You want to deploy a VM with name '" + deploy_vm + "'.."
-    if not d.deploy_host(deploy_vm + digit):
+    if d.deploy_host(deploy_vm + digit) is None:
         sys.exit(1)
     sys.exit(0)

--- a/deploy/post_deploy/nsx_cluster.sh
+++ b/deploy/post_deploy/nsx_cluster.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# We get this passed from the main script
+NSX_MANAGER=$1
+NSX_CONTROLLER=$2
+NSX_SERVICE=$3
+KVM_HOST=$4
+
+NSX_CONTROLLER_IP=$(getent hosts ${NSX_CONTROLLER} | awk '{ print $1 }')
+NSX_SERVICE_IP=$(getent hosts ${NSX_SERVICE} | awk '{ print $1 }')
+KVM_HOST_IP=$(getent hosts ${KVM_HOST} | awk '{ print $1 }')
+
+# Wait for controller to be responding
+while ! ping -c3 ${NSX_CONTROLLER} &>/dev/null; do
+  sleep 2
+done
+
+SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q"
+
+# Create cluster
+echo "Note: Creating NSX cluster"
+sudo yum install -y -q sshpass
+sshpass -p 'admin' ssh ${SSH_OPTIONS} admin@${NSX_CONTROLLER_IP} join control-cluster ${NSX_CONTROLLER_IP}
+sshpass -p 'admin' ssh ${SSH_OPTIONS} admin@${NSX_SERVICE_IP} set switch manager-cluster ${NSX_CONTROLLER_IP}
+
+# login to controller
+echo "Note: Authenticating against controller"
+curl -k -c cookie.txt -X POST -d 'username=admin&password=admin' https://${NSX_CONTROLLER}/ws.v1/login
+
+# wait for cluster to be ready
+echo "Note: waiting for controller to be ready"
+while ! curl -sD - -k -b cookie.txt  https://${NSX_CONTROLLER}/ws.v1/control-cluster  | grep "HTTP/1.1 200"; do
+  sleep 5
+done
+
+# create the transport zone
+echo "Note: Creating Transport Zone"
+curl -k -b cookie.txt -X POST -d '{ "display_name": "mct-zone" }' https://${NSX_CONTROLLER}/ws.v1/transport-zone 2> /dev/null 1> transport-zone.json
+
+# retrieve the transport zone uuid (to use further down the line)
+transportZoneUuid="$(cat transport-zone.json | sed -e 's/^.*"uuid": "//' -e 's/", .*$//')"
+
+# create service node
+echo "Note: Creating Service Node in Zone with UUID = ${transportZoneUuid}"
+curl -k -b cookie.txt -X POST -d '{
+    "credential": {
+        "mgmt_address": "'"${NSX_SERVICE_IP}"'",
+        "type": "MgmtAddrCredential"
+    },
+    "display_name": "mct-service-node",
+    "transport_connectors": [
+        {
+            "ip_address": "'"${NSX_CONTROLLER_IP}"'",
+            "type": "STTConnector",
+            "transport_zone_uuid": "'"${transportZoneUuid}"'"
+        }
+    ],
+    "zone_forwarding": true
+}' https://${NSX_CONTROLLER}/ws.v1/transport-node 2> /dev/null 1> transport-node-service.json
+
+# Setup KVM host
+echo "Note: Getting KVM host certificate"
+kvmOvsCertificate=$(sshpass -p 'password' ssh ${SSH_OPTIONS} root@${KVM_HOST} cat /etc/openvswitch/ovsclient-cert.pem | sed -z "s/\n/\\\\n/g")
+
+echo "Note: Creating KVM host Transport Connector in Zone with UUID = ${transportZoneUuid} "
+curl -k -b cookie.txt -X POST -d '{
+    "credential": {
+        "client_certificate": {
+            "pem_encoded": "'"${kvmOvsCertificate}"'"
+        },
+        "type": "SecurityCertificateCredential"
+    },
+    "display_name": "mct-kvm1-node",
+    "integration_bridge_id": "br-int",
+    "transport_connectors": [
+        {
+            "ip_address": "'"${KVM_HOST_IP}"'",
+            "transport_zone_uuid": "'"${transportZoneUuid}"'",
+            "type": "STTConnector"
+        }
+    ]
+}' https://${NSX_CONTROLLER}/ws.v1/transport-node 2> /dev/null 1> transport-node-kvm1.json
+


### PR DESCRIPTION
`./kvm_local_deploy.py -c nsx_cluster` will now create a NSX cluster with 1 manger, 1 controller, 1 service node and 1 kvm host.

<img width="1198" alt="screen shot 2015-10-27 at 12 27 35" src="https://cloud.githubusercontent.com/assets/4670993/10756786/dca0d278-7ca6-11e5-83ee-e9980ddaada8.png">

Next step is to have a config that adds a new controller to the cluster
