### PR TITLE
Add new controller to cluster NSX

### DIFF
--- a/deploy/postboot/post_nsx_controller.sh
+++ b/deploy/postboot/post_nsx_controller.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+NSX_CONTROLLER=$1
+# We get this passed from the main script
+NEWHOST=$2
+
+NSX_CONTROLLER_IP=$(getent hosts ${NSX_CONTROLLER} | awk '{ print $1 }')
+
+SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q"
+
+sudo yum install -y -q sshpass
+sshpass -p 'admin' ssh ${SSH_OPTIONS} admin@${NEWHOST} join control-cluster ${NSX_CONTROLLER_IP}

--- a/deploy/role/nsx-controller-cluster1.conf
+++ b/deploy/role/nsx-controller-cluster1.conf
@@ -1,0 +1,11 @@
+[role]
+rolename = nsx-controller
+vm_prefix = nsxcon
+offering = small
+hardware = generic
+net_model = virtio
+disk_dev = vda
+disk_bus = virtio
+image = nsx-controller
+firstboot =
+postboot = post_nsx_controller.sh nsxcon1


### PR DESCRIPTION
This PR adds a new role to add a new NSX controller to a cluster. The cluster is the first one added by the cloud config `nsx_cluster`.

Adding controllers to other clusters would require a new role.

This PR builds on top of a PR #25 
