### PR TITLE
Fix bug in build selection

### DIFF
--- a/ci/acs-ci-multijob-dsl.groovy
+++ b/ci/acs-ci-multijob-dsl.groovy
@@ -131,11 +131,13 @@ FOLDERS.each { folderName ->
         phaseJob(runMarvinTestsWithHwJobName) {
           parameters {
             sameNode()
+            prop('CHECKOUT_JOB_BUILD_NUMBER', "\${${checkoutJobName.replaceAll('[^A-Za-z0-9]', '_')}_BUILD_NUMBER}")
           }
         }
         phaseJob(runMarvinTestsWithoutHwJobName) {
           parameters {
             sameNode()
+            prop('CHECKOUT_JOB_BUILD_NUMBER', "\${${checkoutJobName.replaceAll('[^A-Za-z0-9]', '_')}_BUILD_NUMBER}")
           }
         }
       }
@@ -300,6 +302,7 @@ FOLDERS.each { folderName ->
     parameters {
       stringParam('REQUIRED_HARDWARE', null, 'Flag passed to Marvin to select test cases to execute')
       textParam('TESTS', '', 'Set of Marvin tests to execute')
+      stringParam('CHECKOUT_JOB_BUILD_NUMBER', null, 'The build number of the checkout job ran in as part of the multijob')
     }
     concurrentBuild()
     label(EXECUTOR)
@@ -320,7 +323,7 @@ FOLDERS.each { folderName ->
         includePatterns('test/integration/')
         fingerprintArtifacts(true)
         buildSelector {
-          multiJobBuild()
+          buildNumber('${CHECKOUT_JOB_BUILD_NUMBER}')
         }
       }
       shell("${shellPrefix} /data/shared/ci/ci-run-marvin-tests.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg -h \${REQUIRED_HARDWARE} \"\${TESTS}\"")
@@ -333,6 +336,9 @@ FOLDERS.each { folderName ->
   }
 
   freeStyleJob(runMarvinTestsWithHwJobName) {
+    parameters {
+      stringParam('CHECKOUT_JOB_BUILD_NUMBER', null, 'The build number of the checkout job ran in as part of the multijob')
+    }
     concurrentBuild()
     label(EXECUTOR)
     throttleConcurrentBuilds {
@@ -358,6 +364,7 @@ FOLDERS.each { folderName ->
           parameters {
             predefinedProp('REQUIRED_HARDWARE', 'true')
             predefinedProp('TESTS', MARVIN_TESTS_WITH_HARDWARE.join(' '))
+            predefinedProp('CHECKOUT_JOB_BUILD_NUMBER', '${CHECKOUT_JOB_BUILD_NUMBER}')
           }
           sameNode()
         }
@@ -378,6 +385,9 @@ FOLDERS.each { folderName ->
   }
 
   freeStyleJob(runMarvinTestsWithoutHwJobName) {
+    parameters {
+      stringParam('CHECKOUT_JOB_BUILD_NUMBER', null, 'The build number of the checkout job ran in as part of the multijob')
+    }
     concurrentBuild()
     label(EXECUTOR)
     throttleConcurrentBuilds {
@@ -403,6 +413,7 @@ FOLDERS.each { folderName ->
           parameters {
             predefinedProp('REQUIRED_HARDWARE', 'false')
             predefinedProp('TESTS', MARVIN_TESTS_WITHOUT_HARDWARE.join(' '))
+            predefinedProp('CHECKOUT_JOB_BUILD_NUMBER', '${CHECKOUT_JOB_BUILD_NUMBER}')
           }
           sameNode()
         }

--- a/ci/acs-ci-multijob-dsl.groovy
+++ b/ci/acs-ci-multijob-dsl.groovy
@@ -102,7 +102,7 @@ FOLDERS.each { folderName ->
       }
     }
     steps {
-      phase('Checkout Code and Build with Maven') {
+      phase('Checkout Code, Build and Package') {
         phaseJob(checkoutJobName) {
           currentJobParameters(true)
           parameters {

--- a/ci/acs-ci-multijob-dsl.groovy
+++ b/ci/acs-ci-multijob-dsl.groovy
@@ -56,8 +56,8 @@ def CLEAN_UP_JOB_ARTIFACTS = [
 ]
 
 def FOLDERS = [
-  'multijob-build',
-  'multijob-build-dev'
+  'acs-ci-build',
+  'acs-ci-build-dev'
 ]
 
 FOLDERS.each { folderName ->

--- a/ci/acs-ci-multijob-dsl.groovy
+++ b/ci/acs-ci-multijob-dsl.groovy
@@ -63,6 +63,8 @@ def FOLDERS = [
 FOLDERS.each { folderName ->
   folder(folderName)
 
+  def shellPrefix = folderName.endsWith('-dev') ? 'bash -x' : ''
+
   def fullBuildJobName               = "${folderName}/001-full-build"
   def checkoutJobName                = "${folderName}/002-checkout-and-build"
   def deployInfraJobName             = "${folderName}/003-deploy-infra"
@@ -225,7 +227,7 @@ FOLDERS.each { folderName ->
         mavenOpts('-Xmx1024m')
         mavenInstallation('Maven 3.1.1')
       }
-      shell('/data/shared/ci/ci-package-rpms.sh')
+      shell("${shellPrefix} /data/shared/ci/ci-package-rpms.sh")
     }
     publishers {
       archiveArtifacts {
@@ -263,7 +265,7 @@ FOLDERS.each { folderName ->
           multiJobBuild()
         }
       }
-      shell('/data/shared/ci/ci-deploy-infra.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg')
+      shell("${shellPrefix} /data/shared/ci/ci-deploy-infra.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg")
     }
   }
 
@@ -290,7 +292,7 @@ FOLDERS.each { folderName ->
           multiJobBuild()
         }
       }
-      shell('/data/shared/ci/ci-deploy-data-center.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg')
+      shell("${shellPrefix} /data/shared/ci/ci-deploy-data-center.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg")
     }
   }
 
@@ -321,7 +323,7 @@ FOLDERS.each { folderName ->
           multiJobBuild()
         }
       }
-      shell('/data/shared/ci/ci-run-marvin-tests.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg -h ${REQUIRED_HARDWARE} "${TESTS}"')
+      shell("${shellPrefix} /data/shared/ci/ci-run-marvin-tests.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg -h \${REQUIRED_HARDWARE} \"\${TESTS}\"")
     }
     publishers {
       archiveArtifacts {
@@ -436,7 +438,7 @@ FOLDERS.each { folderName ->
     }
     steps {
       shell('rm -rf ./*')
-      shell('/data/shared/ci/ci-cleanup.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg')
+      shell("${shellPrefix} /data/shared/ci/ci-cleanup.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg")
     }
     publishers {
       archiveArtifacts {


### PR DESCRIPTION
This PR fixes a bug in selecting the appropriate checkout job build to retrieve the marvin tests from.
Without this PR the job that runs marvin tests cannot find a build of the checkout job to copy the tests from.

In addition, this PR also:
- renames the build folders
- renames the first phase of the full build job
- prints all bash commands in the dev build (the build that is used for developing the ci itself)
