### PR TITLE
Fix ACS CI build DSL job definition and deploy infra script

### DIFF
--- a/ci/acs-ci-multijob-dsl.groovy
+++ b/ci/acs-ci-multijob-dsl.groovy
@@ -65,8 +65,10 @@ FOLDERS.each { folderName ->
 
   def shellPrefix = folderName.endsWith('-dev') ? 'bash -x' : ''
 
+  def checkoutJobBaseName = '002-checkout-and-build'
+
   def fullBuildJobName               = "${folderName}/001-full-build"
-  def checkoutJobName                = "${folderName}/002-checkout-and-build"
+  def checkoutJobName                = "${folderName}/${checkoutJobBaseName}"
   def deployInfraJobName             = "${folderName}/003-deploy-infra"
   def deployDcJobName                = "${folderName}/004-deploy-data-center"
   def runMarvinTestsWithHwJobName    = "${folderName}/005-run-marvin-tests-with-hardware"
@@ -131,13 +133,13 @@ FOLDERS.each { folderName ->
         phaseJob(runMarvinTestsWithHwJobName) {
           parameters {
             sameNode()
-            prop('CHECKOUT_JOB_BUILD_NUMBER', "\${${checkoutJobName.replaceAll('[^A-Za-z0-9]', '_')}_BUILD_NUMBER}")
+            prop('CHECKOUT_JOB_BUILD_NUMBER', "\${${checkoutJobBaseName.replaceAll('[^A-Za-z0-9]', '_').toUpperCase()}_BUILD_NUMBER}")
           }
         }
         phaseJob(runMarvinTestsWithoutHwJobName) {
           parameters {
             sameNode()
-            prop('CHECKOUT_JOB_BUILD_NUMBER', "\${${checkoutJobName.replaceAll('[^A-Za-z0-9]', '_')}_BUILD_NUMBER}")
+            prop('CHECKOUT_JOB_BUILD_NUMBER', "\${${checkoutJobBaseName.replaceAll('[^A-Za-z0-9]', '_').toUpperCase()}_BUILD_NUMBER}")
           }
         }
       }

--- a/ci/ci-deploy-infra.sh
+++ b/ci/ci-deploy-infra.sh
@@ -47,7 +47,7 @@ function install_kvm_packages {
   ${ssh_base} ${hvuser}@${hvip} systemctl stop cloudstack-agent
   ${ssh_base} ${hvuser}@${hvip} sed -i 's/INFO/DEBUG/g' /etc/cloudstack/agent/log4j-cloud.xml
   ${ssh_base} ${hvuser}@${hvip} cp -pr /etc/cloudstack/agent/agent.properties /etc/cloudstack/agent/agent.properties.orig
-  ${ssh_base} ${hvuser}@${hvip} echo "guest.cpu.mode=host-model" >> /etc/cloudstack/agent/agent.properties
+  ${ssh_base} ${hvuser}@${hvip} "echo \"guest.cpu.mode=host-model\" >> /etc/cloudstack/agent/agent.properties"
   ${ssh_base} ${hvuser}@${hvip} systemctl start cloudstack-agent
 
   say "KVM packages installed in ${hvip}"


### PR DESCRIPTION
This PR fixes two bugs:
- The checkout job build number was not correctly injected into the jobs that run marvin tests
- The deploy infra script was not correctly configuring the KVM agents
