### PR TITLE
implement -b parameter to specify branch 

### DIFF
--- a/helper_scripts/cloudstack/build_run_deploy_test.sh
+++ b/helper_scripts/cloudstack/build_run_deploy_test.sh
@@ -218,6 +218,8 @@ if [ ${skip} -eq 0 ]; then
     else
       echo "No need to patch cloud.spec (${compile_threads})"
     fi
+    # Clean up better
+    rm -rf ../dist/rpmbuild/RPMS/
     # CentOS7 is hardcoded for now
     ./package.sh -d centos7
     if [ $? -ne 0 ]; then

--- a/helper_scripts/cloudstack/check-pr.sh
+++ b/helper_scripts/cloudstack/check-pr.sh
@@ -4,14 +4,14 @@
 # Next, you can run Marvin to setup whatever you need to verify the PR.
 
 function usage {
-  printf "Usage: %s: -m marvinCfg -p <pr id> [ -s <skip compile> -t <run tests> -T <mvn -T flag> ]\n" $(basename $0) >&2
+  printf "Usage: %s: -m marvinCfg -p <pr id> [ -b <branch: default to master> -s <skip compile> -t <run tests> -T <mvn -T flag> ]\n" $(basename $0) >&2
 }
 
 # Options
 skip=
 run_tests=
 compile_threads=
-while getopts 'm:p:T:st' OPTION
+while getopts 'm:p:T:b:st' OPTION
 do
   case $OPTION in
   m)    marvinCfg="$OPTARG"
@@ -24,6 +24,8 @@ do
         ;;
   T)    compile_threads="-T $OPTARG"
         ;;
+  b)    branch_name="$OPTARG"
+        ;;
   esac
 done
 
@@ -33,6 +35,7 @@ echo "run_tests = ${run_tests}"
 echo "marvinCfg = ${marvinCfg}"
 echo "prId = ${prId}"
 echo "compile_threads = ${compile_threads}"
+echo "branch_name = ${branch_name}"
 
 # Check if a marvin dc file was specified
 if [ -z ${marvinCfg} ]; then
@@ -46,6 +49,12 @@ fi
 if [ ! -f "${marvinCfg}" ]; then
     echo "Supplied Marvin config not found!"
     exit 1
+fi
+
+# Default to master branch
+if [ -z "${branch_name}" ]; then
+    branch_name="master"
+    echo "branch_name = ${branch_name}"
 fi
 
 echo "Started!"
@@ -71,8 +80,9 @@ fi
 # Go the the source
 cd /data/git/${HOSTNAME}/cloudstack
 git reset --hard
-git checkout master
-git pull
+git checkout ${branch_name}
+git branch --set-upstream-to=origin/${branch_name} ${branch_name}
+git pull --rebase
 
 # Get the PR
 git branch -D pr/${prId}
@@ -87,10 +97,10 @@ if [ $? -gt 0  ]; then
   exit 1
 fi
 
-# Rebase with current master before tests
-git rebase master
+# Rebase with current ${branch_name} before tests
+git rebase ${branch_name}
 if [ $? -gt 0  ]; then
-  echo "ERROR: Rebase with master failed, please ask author to rebase and force-push commits. Then try again!"
+  echo "ERROR: Rebase with ${branch_name} failed, please ask author to rebase and force-push commits. Then try again!"
   exit 1
 fi
 


### PR DESCRIPTION
We had hardcoded master, that is still the default. Using -b you can now specify -b 4.6.
