### PR TITLE
Latest kvm agent version, nsx cluster service node fix and CI housekeeping

### DIFF
--- a/ci/acs-ci-multijob-dsl.groovy
+++ b/ci/acs-ci-multijob-dsl.groovy
@@ -65,6 +65,7 @@ FOLDERS.each { folderName ->
   folder(folderName)
 
   def shellPrefix = folderName.endsWith('-dev') ? 'bash -x' : ''
+  def executorLabel = EXECUTOR + (folderName.endsWith('-dev') ? '-dev' : '')
 
   def checkoutJobBaseName = '002-checkout-and-build'
 
@@ -82,7 +83,7 @@ FOLDERS.each { folderName ->
       stringParam('sha1', DEFAULT_GIT_REPO_BRANCH, 'Branch to be checked out and built')
     }
     concurrentBuild()
-    label(EXECUTOR)
+    label(executorLabel)
     throttleConcurrentBuilds {
       maxPerNode(1)
     }
@@ -198,7 +199,7 @@ FOLDERS.each { folderName ->
       stringParam('sha1', DEFAULT_GIT_REPO_BRANCH, 'Branch to be checked out and built')
     }
     concurrentBuild()
-    label(EXECUTOR)
+    label(executorLabel)
     throttleConcurrentBuilds {
       maxPerNode(1)
     }
@@ -249,7 +250,7 @@ FOLDERS.each { folderName ->
 
   freeStyleJob(deployInfraJobName) {
     concurrentBuild()
-    label(EXECUTOR)
+    label(executorLabel)
     throttleConcurrentBuilds {
       maxPerNode(1)
     }
@@ -276,7 +277,7 @@ FOLDERS.each { folderName ->
 
   freeStyleJob(deployDcJobName) {
     concurrentBuild()
-    label(EXECUTOR)
+    label(executorLabel)
     throttleConcurrentBuilds {
       maxPerNode(1)
     }
@@ -308,7 +309,7 @@ FOLDERS.each { folderName ->
       stringParam('CHECKOUT_JOB_BUILD_NUMBER', null, 'The build number of the checkout job ran in as part of the multijob')
     }
     concurrentBuild()
-    label(EXECUTOR)
+    label(executorLabel)
     throttleConcurrentBuilds {
       maxPerNode(2)
     }
@@ -343,7 +344,7 @@ FOLDERS.each { folderName ->
       stringParam('CHECKOUT_JOB_BUILD_NUMBER', null, 'The build number of the checkout job ran in as part of the multijob')
     }
     concurrentBuild()
-    label(EXECUTOR)
+    label(executorLabel)
     throttleConcurrentBuilds {
       maxPerNode(2)
     }
@@ -392,7 +393,7 @@ FOLDERS.each { folderName ->
       stringParam('CHECKOUT_JOB_BUILD_NUMBER', null, 'The build number of the checkout job ran in as part of the multijob')
     }
     concurrentBuild()
-    label(EXECUTOR)
+    label(executorLabel)
     throttleConcurrentBuilds {
       maxPerNode(2)
     }
@@ -438,7 +439,7 @@ FOLDERS.each { folderName ->
 
   freeStyleJob(cleanUpJobName) {
     concurrentBuild()
-    label(EXECUTOR)
+    label(executorLabel)
     throttleConcurrentBuilds {
       maxPerNode(1)
     }

--- a/ci/acs-ci-multijob-dsl.groovy
+++ b/ci/acs-ci-multijob-dsl.groovy
@@ -52,7 +52,8 @@ def CLEAN_UP_JOB_ARTIFACTS = [
   'vmops.log*',
   'api.log*',
   'kvm1-agent-logs/',
-  'kvm2-agent-logs/'
+  'kvm2-agent-logs/',
+  'MarvinLogs/'
 ]
 
 def FOLDERS = [

--- a/deploy/firstboot/centos7-kvm-ovs.sh
+++ b/deploy/firstboot/centos7-kvm-ovs.sh
@@ -24,8 +24,8 @@ systemctl disable firewalld
 sleep 5
 yum -y install http://mirror.karneval.cz/pub/linux/fedora/epel/epel-release-latest-7.noarch.rpm
 yum -y install qemu-kvm libvirt libvirt-python net-tools bridge-utils vconfig setroubleshoot virt-top virt-manager openssh-askpass wget vim
-yum -y install http://jenkins.buildacloud.org/job/package-centos7-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64/cloudstack-common-4.6.0-SNAPSHOT.el7.centos.x86_64.rpm
-yum -y install http://jenkins.buildacloud.org/job/package-centos7-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64/cloudstack-agent-4.6.0-SNAPSHOT.el7.centos.x86_64.rpm
+yum -y install http://jenkins.buildacloud.org/job/package-centos7-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64/cloudstack-common-4.7.0-SNAPSHOT.el7.centos.x86_64.rpm
+yum -y install http://jenkins.buildacloud.org/job/package-centos7-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64/cloudstack-agent-4.7.0-SNAPSHOT.el7.centos.x86_64.rpm
 yum --enablerepo=epel -y install sshpass
 
 # Enable rpbind for NFS

--- a/deploy/firstboot/centos7-kvm.sh
+++ b/deploy/firstboot/centos7-kvm.sh
@@ -12,8 +12,8 @@ systemctl disable firewalld
 sleep 5
 yum -y install http://mirror.karneval.cz/pub/linux/fedora/epel/epel-release-latest-7.noarch.rpm
 yum -y install qemu-kvm libvirt libvirt-python net-tools bridge-utils vconfig setroubleshoot virt-top virt-manager openssh-askpass wget vim
-yum -y install http://jenkins.buildacloud.org/job/package-centos7-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64/cloudstack-common-4.6.0-SNAPSHOT.el7.centos.x86_64.rpm 
-yum -y install http://jenkins.buildacloud.org/job/package-centos7-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64/cloudstack-agent-4.6.0-SNAPSHOT.el7.centos.x86_64.rpm
+yum -y install http://jenkins.buildacloud.org/job/package-centos7-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64/cloudstack-common-4.7.0-SNAPSHOT.el7.centos.x86_64.rpm
+yum -y install http://jenkins.buildacloud.org/job/package-centos7-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64/cloudstack-agent-4.7.0-SNAPSHOT.el7.centos.x86_64.rpm
 yum --enablerepo=epel -y install sshpass
 
 # Enable rpbind for NFS

--- a/deploy/post_deploy/nsx_cluster.sh
+++ b/deploy/post_deploy/nsx_cluster.sh
@@ -50,7 +50,7 @@ curl -k -b cookie.txt -X POST -d '{
     "display_name": "mct-service-node",
     "transport_connectors": [
         {
-            "ip_address": "'"${NSX_CONTROLLER_IP}"'",
+            "ip_address": "'"${NSX_SERVICE_IP}"'",
             "type": "STTConnector",
             "transport_zone_uuid": "'"${transportZoneUuid}"'"
         }


### PR DESCRIPTION
This PR does 4 things:
- Install kvm agent version 4.7.0
- Configure NSX service node connector to point to service node IP
- Enable CI dev jobs to run on dev slave
- Archives Marvin logs after CI build
