### PR TITLE
Enable deploying new KVM hosts in NSX cluster

### DIFF
--- a/deploy/post_deploy/nsx_cluster.sh
+++ b/deploy/post_deploy/nsx_cluster.sh
@@ -62,7 +62,7 @@ curl -k -b cookie.txt -X POST -d '{
 echo "Note: Getting KVM host certificate"
 kvmOvsCertificate=$(sshpass -p 'password' ssh ${SSH_OPTIONS} root@${KVM_HOST} cat /etc/openvswitch/ovsclient-cert.pem | sed -z "s/\n/\\\\n/g")
 
-echo "Note: Creating KVM host Transport Connector in Zone with UUID = ${transportZoneUuid} "
+echo "Note: Creating KVM host (${KVM_HOST}) Transport Connector in Zone with UUID = ${transportZoneUuid} "
 curl -k -b cookie.txt -X POST -d '{
     "credential": {
         "client_certificate": {
@@ -70,7 +70,7 @@ curl -k -b cookie.txt -X POST -d '{
         },
         "type": "SecurityCertificateCredential"
     },
-    "display_name": "mct-kvm1-node",
+    "display_name": "mct-'"${KVM_HOST}"'-node",
     "integration_bridge_id": "br-int",
     "transport_connectors": [
         {
@@ -79,5 +79,5 @@ curl -k -b cookie.txt -X POST -d '{
             "type": "STTConnector"
         }
     ]
-}' https://${NSX_CONTROLLER}/ws.v1/transport-node 2> /dev/null 1> transport-node-kvm1.json
+}' https://${NSX_CONTROLLER}/ws.v1/transport-node 2> /dev/null 1> transport-node-${KVM_HOST}.json
 

--- a/deploy/postboot/post_nsx_controller.sh
+++ b/deploy/postboot/post_nsx_controller.sh
@@ -6,7 +6,12 @@ NEWHOST=$2
 
 NSX_CONTROLLER_IP=$(getent hosts ${NSX_CONTROLLER} | awk '{ print $1 }')
 
-SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q"
+SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
 sudo yum install -y -q sshpass
+
+echo "Joining cluster"
 sshpass -p 'admin' ssh ${SSH_OPTIONS} admin@${NEWHOST} join control-cluster ${NSX_CONTROLLER_IP}
+
+echo "Restarting initial controller"
+sshpass -p 'admin' ssh ${SSH_OPTIONS} admin@${NSX_CONTROLLER} restart controller

--- a/deploy/postboot/post_nsx_controller.sh
+++ b/deploy/postboot/post_nsx_controller.sh
@@ -12,6 +12,3 @@ sudo yum install -y -q sshpass
 
 echo "Joining cluster"
 sshpass -p 'admin' ssh ${SSH_OPTIONS} admin@${NEWHOST} join control-cluster ${NSX_CONTROLLER_IP}
-
-echo "Restarting initial controller"
-sshpass -p 'admin' ssh ${SSH_OPTIONS} admin@${NSX_CONTROLLER} restart controller

--- a/deploy/postboot/post_nsx_hypervisor.sh
+++ b/deploy/postboot/post_nsx_hypervisor.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# We get this passed from the main script
+NSX_CONTROLLER=$1
+KVM_HOST=$2
+
+KVM_HOST_IP=$(getent hosts ${KVM_HOST} | awk '{ print $1 }')
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+${DIR}/post_detect_reboot.sh ${KVM_HOST}
+
+# Wait for controller to be responding
+while ! ping -c3 ${NSX_CONTROLLER} &>/dev/null; do
+  sleep 2
+done
+
+SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q"
+
+echo "Note: Authenticating against controller"
+curl -k -c cookie.txt -X POST -d 'username=admin&password=admin' https://${NSX_CONTROLLER}/ws.v1/login
+
+echo "Note: waiting for controller to be ready"
+while ! curl -sD - -k -b cookie.txt  https://${NSX_CONTROLLER}/ws.v1/control-cluster  | grep "HTTP/1.1 200"; do
+  sleep 5
+done
+
+echo "Note: Retrieving Transport Zone"
+curl -k -b cookie.txt https://${NSX_CONTROLLER}/ws.v1/transport-zone 2> /dev/null 1> transport-zone-list.json
+# retrieve the transport zone uuid (to use further down the line)
+transportZoneUuid="$(cat transport-zone-list.json | sed -e 's/^.*transport-zone\///' -e 's/".*$//')"
+
+echo "Note: Getting KVM host certificate"
+kvmOvsCertificate=$(sshpass -p 'password' ssh ${SSH_OPTIONS} root@${KVM_HOST} cat /etc/openvswitch/ovsclient-cert.pem | sed -z "s/\n/\\\\n/g")
+
+echo "Note: Creating KVM host (${KVM_HOST}) Transport Connector in Zone with UUID = ${transportZoneUuid} "
+curl -k -b cookie.txt -X POST -d '{
+    "credential": {
+        "client_certificate": {
+            "pem_encoded": "'"${kvmOvsCertificate}"'"
+        },
+        "type": "SecurityCertificateCredential"
+    },
+    "display_name": "mct-'"${KVM_HOST}"'-node",
+    "integration_bridge_id": "br-int",
+    "transport_connectors": [
+        {
+            "ip_address": "'"${KVM_HOST_IP}"'",
+            "transport_zone_uuid": "'"${transportZoneUuid}"'",
+            "type": "STTConnector"
+        }
+    ]
+}' https://${NSX_CONTROLLER}/ws.v1/transport-node 2> /dev/null 1> transport-node-${KVM_HOST}.json

--- a/deploy/role/kvm_ovs-cluster1.conf
+++ b/deploy/role/kvm_ovs-cluster1.conf
@@ -1,0 +1,11 @@
+[role]
+rolename = kvm_ovs
+vm_prefix = kvm
+offering = large
+hardware = openvswitch
+net_model = virtio
+disk_dev = vda
+disk_bus = virtio
+image = centos7
+firstboot = centos7-kvm-ovs.sh
+postboot = post_nsx_hypervisor.sh nsxcon1

--- a/marvin/mct-zone1-kvm1-kvm2-NVP.cfg
+++ b/marvin/mct-zone1-kvm1-kvm2-NVP.cfg
@@ -111,6 +111,11 @@
                                     "username": "root",
                                     "url": "http://kvm1",
                                     "password": "password"
+                                },
+                                {
+                                    "username": "root",
+                                    "url": "http://kvm2",
+                                    "password": "password"
                                 }
                             ],
                             "clustertype": "CloudManaged",


### PR DESCRIPTION
This PR adds a new role for adding KVM hosts to an existing nsx cluster (controller needs to be nsxcon1).
In addition it prepares the NVP marvin config to have two kvm hosts, and cleans up/syncs some other scripts.
