### PR TITLE
The tests have moved from component to smoke directory

### DIFF
--- a/helper_scripts/cloudstack/run_marvin_router_tests.sh
+++ b/helper_scripts/cloudstack/run_marvin_router_tests.sh
@@ -14,12 +14,12 @@ cd /data/git/${HOSTNAME}/cloudstack/test/integration
 
 echo "Running tests with required_hardware=true"
 nosetests --with-marvin --marvin-config=${marvinCfg} -s -a tags=advanced,required_hardware=true \
-component/test_vpc_redundant.py \
-component/test_routers_iptables_default_policy.py \
-component/test_routers_network_ops.py \
-component/test_vpc_router_nics.py \
 component/test_password_server.py \
-component/test_router_dhcphosts.py \
+smoke/test_vpc_redundant.py \
+smoke/test_routers_iptables_default_policy.py \
+smoke/test_routers_network_ops.py \
+smoke/test_vpc_router_nics.py \
+smoke/test_router_dhcphosts.py \
 smoke/test_loadbalance.py \
 smoke/test_internal_lb.py \
 smoke/test_ssvm.py \


### PR DESCRIPTION
Ping @remibergsma @neubauerf @miguelaferreira 

Moving the tests since they have moved on ACS and were already merged.

By the way, I forgot to move the test_password_server.py from component to smoke, where it belongs. I will do so in my next PR and then change MCT as well..
