### PR TITLE
Decreasing the interval that Network GC uses to clean up networks

### DIFF
--- a/marvin/mct-zone1-kvm1-ISOLATED.cfg
+++ b/marvin/mct-zone1-kvm1-ISOLATED.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-kvm1-basic.cfg
+++ b/marvin/mct-zone1-kvm1-basic.cfg
@@ -165,6 +165,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-kvm1-kvm2-NVP.cfg
+++ b/marvin/mct-zone1-kvm1-kvm2-NVP.cfg
@@ -210,6 +210,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-kvm1-kvm2.cfg
+++ b/marvin/mct-zone1-kvm1-kvm2.cfg
@@ -181,6 +181,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-kvm1-s3secstor.cfg
+++ b/marvin/mct-zone1-kvm1-s3secstor.cfg
@@ -197,6 +197,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-kvm1.cfg
+++ b/marvin/mct-zone1-kvm1.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-xen1-ISOLATED.cfg
+++ b/marvin/mct-zone1-xen1-ISOLATED.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-xen1-basic.cfg
+++ b/marvin/mct-zone1-xen1-basic.cfg
@@ -165,6 +165,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-xen1-xen2.cfg
+++ b/marvin/mct-zone1-xen1-xen2.cfg
@@ -181,6 +181,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone1-xen1.cfg
+++ b/marvin/mct-zone1-xen1.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone2-kvm2-ISOLATED.cfg
+++ b/marvin/mct-zone2-kvm2-ISOLATED.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone2-kvm2-basic.cfg
+++ b/marvin/mct-zone2-kvm2-basic.cfg
@@ -165,6 +165,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone2-kvm2.cfg
+++ b/marvin/mct-zone2-kvm2.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone2-xen2-ISOLATED.cfg
+++ b/marvin/mct-zone2-xen2-ISOLATED.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone2-xen2.cfg
+++ b/marvin/mct-zone2-xen2.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone3-kvm3-ISOLATED.cfg
+++ b/marvin/mct-zone3-kvm3-ISOLATED.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone3-kvm3-OVS.cfg
+++ b/marvin/mct-zone3-kvm3-OVS.cfg
@@ -180,6 +180,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone3-kvm3-basic.cfg
+++ b/marvin/mct-zone3-kvm3-basic.cfg
@@ -165,6 +165,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone3-kvm3-kvm4.cfg
+++ b/marvin/mct-zone3-kvm3-kvm4.cfg
@@ -181,6 +181,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone3-kvm3.cfg
+++ b/marvin/mct-zone3-kvm3.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone3-xen3-OVS.cfg
+++ b/marvin/mct-zone3-xen3-OVS.cfg
@@ -180,6 +180,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone3-xen3-xen4.cfg
+++ b/marvin/mct-zone3-xen3-xen4.cfg
@@ -181,6 +181,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [

--- a/marvin/mct-zone3-xen3.cfg
+++ b/marvin/mct-zone3-xen3.cfg
@@ -176,6 +176,14 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
         }
     ],
     "mgtSvr": [


### PR DESCRIPTION
- This will be used in the test in order to avoid a long time (2 minutes now) sleep.
- We can rely in the time and sleep based on what the DC global settings offer.
