### PR TITLE
pull before checkout to get all new branches

### DIFF
--- a/helper_scripts/cloudstack/check-pr.sh
+++ b/helper_scripts/cloudstack/check-pr.sh
@@ -79,6 +79,7 @@ fi
 
 # Go the the source
 cd /data/git/${HOSTNAME}/cloudstack
+git pull
 git reset --hard
 git checkout ${branch_name}
 git branch --set-upstream-to=origin/${branch_name} ${branch_name}


### PR DESCRIPTION
This prevents that a new branch cannot be found on the first run. Happened with the new 4.7 branch. With this fix it works without manual intervention.
