### PR TITLE
Add NSX specific config values

### DIFF
--- a/marvin/mct-zone1-kvm1-kvm2-NVP.cfg
+++ b/marvin/mct-zone1-kvm1-kvm2-NVP.cfg
@@ -233,6 +233,17 @@
         }
     ],
     "niciraNvp": {
-    	"hosts": [ "nsxcon1.cloud.lan", "nsxcon2.cloud.lan" ]
+        "hosts": [ "nsxcon1.cloud.lan", "nsxcon2.cloud.lan", "nsxcon3.cloud.lan" ],
+        "shared_network": {
+            "l2gatewayserviceuuid": "<UUID of L2 Gateway Service>",
+            "iprange" : {
+                "startip": "192.168.26.2",
+                "endip": "192.168.26.20",
+                "netmask": "255.255.255.0",
+                "gateway": "192.168.26.1",
+                "vlan": "50",
+                "vlan_uuid": "<UUID of LRouter>"
+            }
+        }
     }
 }


### PR DESCRIPTION
NXS tests need a few more configuration parameters. This PR adds those.
This config file needs to be adapted with the missing UUIDs.

Later, the test it self should be refactored to read those values from the NSX api when setting up.
