### PR TITLE
Set garbage_collector timers before mgt server start

### DIFF
--- a/helper_scripts/cloudstack/build_run_deploy_test.sh
+++ b/helper_scripts/cloudstack/build_run_deploy_test.sh
@@ -323,6 +323,9 @@ date
 mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'host', '$host_ip') ON DUPLICATE KEY UPDATE value = '$host_ip';"
 # Insert OVS bridge
 mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'sdn.ovs.controller.default.label', 'cloudbr0') ON DUPLICATE KEY UPDATE value = 'cloudbr0';"
+# Garbage collector
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'network.gc.interval', '60') ON DUPLICATE KEY UPDATE value = '60';"
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'network.gc.wait', '60') ON DUPLICATE KEY UPDATE value = '60';"
 
 # Adding the right SystemVMs, for both KVM and XenServer
 # Adding the tiny linux VM templates for KVM and XenServer


### PR DESCRIPTION
This prevents test case failures because the GC timers are read from the DB (tests wait this long) but in reality are not the actual settings before the global settings need a management server restart.
