### PR TITLE
Adds Cosmic helper scripts

### DIFF
--- a/helper_scripts/cosmic/add_os_templates.sh
+++ b/helper_scripts/cosmic/add_os_templates.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cloudmonkey set table default
+TEMPOSID=$(cloudmonkey list ostypes keyword="Other PV (64-bit)" filter=id | grep ^id | awk {'print $3'})
+# XenServer
+cloudmonkey register template displayText=Tiny format=VHD hypervisor=XenServer isextractable=true isfeatured=true ispublic=true isrouting=false name=Tiny osTypeId=$TEMPOSID passwordEnabled=true requireshvm=true zoneid=-1 url=http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-xen.vhd.bz2
+# KVM
+cloudmonkey register template displayText=Tiny format=Qcow2 hypervisor=KVM isextractable=true isfeatured=true ispublic=true isrouting=false name=Tiny osTypeId=$TEMPOSID passwordEnabled=true requireshvm=true zoneid=-1 url=http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-kvm.qcow2.bz2

--- a/helper_scripts/cosmic/build_run.sh
+++ b/helper_scripts/cosmic/build_run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+host_ip=`ip addr | grep 'inet 192' | cut -d: -f2 | awk '{ print $2 }' | awk -F\/24 '{ print $1 }'`
+
+COSMIC_BUILD_PATH=/data/git/$HOSTNAME/cosmic
+COSMIC_RUN_PATH=$COSMIC_BUILD_PATH/cosmic-core
+
+# We work from here
+# Compile ACS
+cd $COSMIC_BUILD_PATH
+mvn clean install -P developer,systemvm
+# Deploy DB
+cd $COSMIC_RUN_PATH
+mvn -P developer -pl developer -Ddeploydb
+# Configure the hostname properly - it doesn't exist if the deployeDB doesn't include devcloud
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'host', '$host_ip') ON DUPLICATE KEY UPDATE value = '$host_ip';"
+# Insert OVS bridge
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'sdn.ovs.controller.default.label', 'cloudbr0') ON DUPLICATE KEY UPDATE value = 'cloudbr0';"
+
+# Adding the right SystemVMs, for both KVM and Xen
+# Adding the tiny linux VM templates for KVM and Xen
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://jenkins.buildacloud.org/job/build-systemvm64-master/lastSuccessfulBuild/artifact/tools/appliance/dist/systemvm64template-master-4.6.0-xen.vhd.bz2' where id=1;"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://jenkins.buildacloud.org/job/build-systemvm64-master/lastSuccessfulBuild/artifact/tools/appliance/dist/systemvm64template-master-4.6.0-kvm.qcow2.bz2' where id=3;"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-kvm.qcow2.bz2', guest_os_id=140, name='tiny linux kvm', display_text='tiny linux kvm', hvm=1 where id=4;"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-xen.vhd.bz2', guest_os_id=140, name='tiny linux xenserver', display_text='tiny linux xenserver', hvm=1 where id=2;"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-xen.vhd.bz2', guest_os_id=140, name='tiny linux xenserver', display_text='tiny linux xenserver', hvm=1 where id=5;"
+
+# Make service offering support HA
+mysql -u cloud -pcloud cloud --exec "UPDATE service_offering SET ha_enabled = 1;"
+
+# Install Marvin
+pip install --upgrade tools/marvin/dist/Marvin-*.tar.gz --allow-external mysql-connector-python
+
+# Run mgt
+mvn -pl :cloud-client-ui jetty:run

--- a/helper_scripts/cosmic/build_run_deploy_test.sh
+++ b/helper_scripts/cosmic/build_run_deploy_test.sh
@@ -1,0 +1,407 @@
+#!/bin/bash
+
+# This script builds and runs Cosmic and deploys a data center using the supplied Marvin config.
+# When KVM is used, RPMs are built and installed on the hypervisor.
+# When done, it runs the desired tests.
+
+function usage {
+  printf "Usage: %s: -m marvinCfg [ -s <skip compile> -t <run tests> -T <mvn -T flag> ]\n" $(basename $0) >&2
+}
+
+# Options
+skip=0
+run_tests=0
+compile_threads=
+while getopts 'm:T:st' OPTION
+do
+  case $OPTION in
+  m)    marvinCfg="$OPTARG"
+        ;;
+  s)    skip=1
+        ;;
+  t)    run_tests=1
+        ;;
+  T)    compile_threads="-T $OPTARG"
+        ;;
+  esac
+done
+
+echo "Received arguments:"
+echo "skip = ${skip}"
+echo "run_tests = ${run_tests}"
+echo "marvinCfg = ${marvinCfg}"
+echo "compile_threads = ${compile_threads}"
+
+# Check if a marvin dc file was specified
+if [ -z ${marvinCfg} ]; then
+  echo "No Marvin config specified. Quiting."
+  usage
+  exit 1
+else
+  echo "Using Marvin config '${marvinCfg}'."
+fi
+
+if [ ! -f "${marvinCfg}" ]; then
+    echo "Supplied Marvin config not found!"
+    exit 1
+fi
+
+echo "Started!"
+date
+
+# Find ip
+host_ip=`ip addr | grep 'inet 192' | cut -d: -f2 | awk '{ print $2 }' | awk -F\/24 '{ print $1 }'`
+
+COSMIC_BUILD_PATH=/data/git/$HOSTNAME/cosmic
+COSMIC_RUN_PATH=$COSMIC_BUILD_PATH/cosmic-core
+
+# We work from here
+cd $COSMIC_BUILD_PATH
+
+if [ $? -gt 0  ]; then
+  echo "ERROR: git repo not found!"
+  exit 1
+fi
+
+echo "OK"
+
+# Parse marvin config
+# This should be done in python instead,
+# for now we just hack the common usecase together
+
+# All we support is a single cluster with 1 or 2 hypervisors.
+
+# We grab some useful info from the supplied Marvin json file.
+
+# Zone name
+zone=$(cat ${marvinCfg} | grep -v "#" | python -c "
+import sys, json
+print json.load(sys.stdin)['zones'][0]['name']
+")
+
+# Hypervisor type
+hypervisor=$(cat ${marvinCfg} | grep -v "#" | python -c "
+import sys, json
+print json.load(sys.stdin)['zones'][0]['pods'][0]['clusters'][0]['hypervisor'].lower()
+")
+
+# Primary storage location
+primarystorage=$(cat ${marvinCfg} | grep -v "#" | python -c "
+import sys, json
+print json.load(sys.stdin)['zones'][0]['pods'][0]['clusters'][0]['primaryStorages'][0]['url']" | cut -d: -f3
+)
+mkdir -p ${primarystorage}
+
+secondarystorage=$(cat ${marvinCfg} | grep -v "#" | python -c "
+import sys, json
+print json.load(sys.stdin)['zones'][0]['secondaryStorages'][0]['url']" | cut -d: -f3
+)
+mkdir -p ${secondarystorage}
+
+# username hypervisor 1
+hvuser1=$(cat ${marvinCfg} | grep -v "#" | python -c "
+try:
+  import sys, json
+  print json.load(sys.stdin)['zones'][0]['pods'][0]['clusters'][0]['hosts'][0]['username']
+except:
+ print ''
+")
+
+# password hypervisor 1
+hvpass1=$(cat ${marvinCfg} | grep -v "#" | python -c "
+try:
+  import sys, json
+  print json.load(sys.stdin)['zones'][0]['pods'][0]['clusters'][0]['hosts'][0]['password']
+except:
+ print ''
+")
+
+# ip adress hypervisor 1
+hvip1=$(cat ${marvinCfg} | grep -v "#" | python -c "
+try:
+  import sys, json
+  print json.load(sys.stdin)['zones'][0]['pods'][0]['clusters'][0]['hosts'][0]['url']
+except:
+ print ''
+" | cut -d/ -f3)
+
+# username hypervisor 2
+hvuser2=$(cat ${marvinCfg} | grep -v "#" | python -c "
+try:
+  import sys, json
+  print json.load(sys.stdin)['zones'][0]['pods'][0]['clusters'][0]['hosts'][1]['username']
+except:
+ print ''
+")
+
+# password hypervisor 2
+hvpass2=$(cat ${marvinCfg} | grep -v "#" | python -c "
+try:
+  import sys, json
+  print json.load(sys.stdin)['zones'][0]['pods'][0]['clusters'][0]['hosts'][1]['password']
+except:
+ print ''
+")
+
+# ip adress hypervisor 2
+hvip2=$(cat ${marvinCfg} | grep -v "#" | python -c "
+try:
+  import sys, json
+  print json.load(sys.stdin)['zones'][0]['pods'][0]['clusters'][0]['hosts'][1]['url']
+except:
+ print ''
+" | cut -d/ -f3)
+
+hasNsxDevice=$(cat ${marvinCfg} | grep -v "#" | python -c "
+try:
+  import sys, json
+  jsonObject = json.load(sys.stdin)
+  niciraProviders = filter(lambda provider: provider['name'] == 'NiciraNvp', reduce(lambda a, b: a+b, map(lambda physical_net: physical_net['providers'], jsonObject['zones'][0]['physical_networks'])))
+  if niciraProviders:
+    print True
+  else:
+    print False
+except:
+ print ERROR
+")
+
+if [ "$hasNsxDevice" == "ERROR" ]; then
+  echo "Failed to detect NSX provider in Marvin config"
+  exit 10
+fi
+
+# Install Cosmic packages to KVM
+function install_kvm_packages {
+  # Parameters
+  hvip=$1
+  hvuser=$2
+  hvpass=$3
+  hasNsxDevice=$4
+
+  # SSH/SCP helpers
+  ssh_base="sshpass -p ${hvpass} ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=quiet -t "
+  scp_base="sshpass -p ${hvpass} scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=quiet "
+
+  # scp packages to hypervisor, remove existing, then install new ones
+  ${ssh_base} ${hvuser}@${hvip} rm cloudstack-*
+  ${scp_base} ../dist/rpmbuild/RPMS/x86_64/* ${hvuser}@${hvip}:
+  ${ssh_base} ${hvuser}@${hvip} yum -y remove cloudstack-common
+  ${ssh_base} ${hvuser}@${hvip} rm -f /etc/cloudstack/agent/agent.properties
+  ${ssh_base} ${hvuser}@${hvip} yum -y localinstall cloudstack-agent* cloudstack-common*
+  if [ "$hasNsxDevice" == "True" ]; then
+    ${ssh_base} ${hvuser}@${hvip} 'echo "libvirt.vif.driver=com.cloud.hypervisor.kvm.resource.OvsVifDriver" >> /etc/cloudstack/agent/agent.properties'
+    ${ssh_base} ${hvuser}@${hvip} 'echo "network.bridge.type=openvswitch" >> /etc/cloudstack/agent/agent.properties'
+    ${ssh_base} ${hvuser}@${hvip} 'echo "guest.cpu.mode=host-model" >> /etc/cloudstack/agent/agent.properties'
+  fi
+}
+
+function clean_kvm {
+  # Parameters
+  hvip=$1
+  hvuser=$2
+  hvpass=$3
+
+  # SSH/SCP helpers
+  ssh_base="sshpass -p ${hvpass} ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=quiet -t "
+  scp_base="sshpass -p ${hvpass} scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=quiet "
+
+  # Clean KVM in case it has been used before
+  ${ssh_base} ${hvuser}@${hvip} systemctl daemon-reload
+  ${ssh_base} ${hvuser}@${hvip} systemctl stop cloudstack-agent
+  ${ssh_base} ${hvuser}@${hvip} systemctl disable cloudstack-agent
+  ${ssh_base} ${hvuser}@${hvip} systemctl restart libvirtd
+  ${ssh_base} ${hvuser}@${hvip} sed -i 's/INFO/DEBUG/g' /etc/cloudstack/agent/log4j-cloud.xml
+  ${ssh_base} ${hvuser}@${hvip} "for host in \$(virsh list | awk '{print \$2;}' | grep -v Name |egrep -v '^\$'); do virsh destroy \$host; done"
+}
+
+function clean_xenserver {
+  # Parameters
+  hvip=$1
+  hvuser=$2
+  hvpass=$3
+
+  /data/shared/helper_scripts/cleaning/xapi_cleanup_xenservers.py http://${hvip} ${hvuser} ${hvpass}
+
+}
+
+# Stop previous mgt server
+killall -9 java
+while timeout 1 bash -c 'cat < /dev/null > /dev/tcp/localhost/8096' 2>&1 > /dev/null; do echo "Waiting for socket to close.."; sleep 10; done
+
+# Cleanup UI cached items
+find /data/git/$HOSTNAME/cosmic/cosmic-core/client -name \*.gz | xargs rm -f
+
+# Compile Cosmic
+if [ ${skip} -eq 0 ]; then
+
+  # Compile RPM packages for KVM hypervisor
+  # When something VR related is changed, one must use the RPMs from the branch we're testing
+  if [[ "$hypervisor" == "kvm" ]]; then
+    echo "Creating rpm packages for ${hypervisor}"
+    date
+    cd $COSMIC_RUN_PATH/packaging
+
+    # Use 4 cores when compiling ACS
+    if [ ! -z "${compile_threads}" ]; then
+      echo "Patching cloud.spec (${compile_threads})"
+      sed -i "/mvn -Psystemvm -DskipTests/c\mvn -Psystemvm -DskipTests \$FLAGS clean package ${compile_threads}" $COSMIC_RUN_PATH/packaging/centos7/cloud.spec
+    else
+      echo "No need to patch cloud.spec (${compile_threads})"
+    fi
+    # Clean up better
+    rm -rf ../dist/rpmbuild/RPMS/
+    # CentOS7 is hardcoded for now
+    ./package.sh -d centos7
+    if [ $? -ne 0 ]; then
+      date
+      echo "RPM build failed, please investigate!"
+      exit 1
+    fi
+
+    # Done, put it back
+    git reset --hard
+
+    # Push to hypervisor
+    install_kvm_packages ${hvip1} ${hvuser1} ${hvpass1} ${hasNsxDevice}
+    date
+
+    # Do we have a second hypervisor
+    if [ ! -z  ${hvip2} ]; then
+      # Push to hypervisor
+      install_kvm_packages ${hvip2} ${hvuser2} ${hvpass2} ${hasNsxDevice}
+    fi
+
+    # We do not need to clean the next compile
+    clean=""
+  else
+    echo "No RPM packages needed for ${hypervisor}"
+
+    # We use clean here since we didn't compile rpms
+    clean="clean"
+  fi
+
+  # Compile Cosmic
+  cd "$COSMIC_BUILD_PATH"
+  echo "Compiling Cosmic"
+  date
+  mvn ${clean} install -P developer,systemvm ${compile_threads}
+  if [ $? -ne 0 ]; then
+    date
+    echo "Build failed, please investigate!"
+    exit 1
+  fi
+  date
+fi
+
+# Cleaning Hypervisor
+echo "Cleaning hypervisor"
+if [[ "$hypervisor" == "kvm" ]]; then
+    clean_kvm ${hvip1} ${hvuser1} ${hvpass1}
+
+    # Do we have a second hypervisor
+    if [ ! -z  ${hvip2} ]; then
+      clean_kvm ${hvip2} ${hvuser2} ${hvpass2}
+    fi
+elif [[ "$hypervisor" == "xenserver" ]]; then
+    clean_xenserver ${hvip1} ${hvuser1} ${hvpass1}
+
+    # Do we have a second hypervisor
+    if [ ! -z  ${hvip2} ]; then
+      # Push to hypervisor
+      clean_xenserver ${hvip2} ${hvuser2} ${hvpass2}
+    fi
+fi
+
+cd "$COSMIC_RUN_PATH"
+# Deploy DB
+echo "Deploying Cosmic DB"
+mvn -P developer -pl developer -Ddeploydb -T 4
+if [ $? -ne 0 ]; then
+  date
+  echo "Build failed, please investigate!"
+  exit 1
+fi
+date
+
+# Configure the hostname properly - it doesn't exist if the deployeDB doesn't include devcloud
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'host', '$host_ip') ON DUPLICATE KEY UPDATE value = '$host_ip';"
+# Insert OVS bridge
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'sdn.ovs.controller.default.label', 'cloudbr0') ON DUPLICATE KEY UPDATE value = 'cloudbr0';"
+# Garbage collector
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'network.gc.interval', '60') ON DUPLICATE KEY UPDATE value = '60';"
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'network.gc.wait', '60') ON DUPLICATE KEY UPDATE value = '60';"
+
+# Adding the right SystemVMs, for both KVM and XenServer
+# Adding the tiny linux VM templates for KVM and XenServer
+echo "Config Templates"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://jenkins.buildacloud.org/job/build-systemvm64-master/lastSuccessfulBuild/artifact/tools/appliance/dist/systemvm64template-master-4.6.0-xen.vhd.bz2' where id=1;"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://jenkins.buildacloud.org/job/build-systemvm64-master/lastSuccessfulBuild/artifact/tools/appliance/dist/systemvm64template-master-4.6.0-kvm.qcow2.bz2' where id=3;"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-kvm.qcow2.bz2', guest_os_id=140, name='tiny linux kvm', display_text='tiny linux kvm', hvm=1 where id=4;"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-xen.vhd.bz2', guest_os_id=140, name='tiny linux xenserver', display_text='tiny linux xenserver', hvm=1 where id=2;"
+mysql -u cloud -pcloud cloud --exec "UPDATE cloud.vm_template SET url='http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-xen.vhd.bz2', guest_os_id=140, name='tiny linux xenserver', display_text='tiny linux xenserver', hvm=1 where id=5;"
+
+# Make service offering support HA
+echo "Set all offerings to HA"
+mysql -u cloud -pcloud cloud --exec "UPDATE service_offering SET ha_enabled = 1;"
+mysql -u cloud -pcloud cloud --exec "UPDATE vm_instance SET ha_enabled = 1;"
+
+# Install Marvin
+echo "Installing Marvin"
+pip install --upgrade tools/marvin/dist/Marvin-*.tar.gz --allow-external mysql-connector-python
+
+# Run the Cosmic management server
+echo "Double checking Cosmic is not already running"
+killall -9 java
+while timeout 1 bash -c 'cat < /dev/null > /dev/tcp/localhost/8096' 2>&1 > /dev/null; do echo "Waiting for socket to close.."; sleep 10; done
+
+# Compile Cosmic
+cd "$COSMIC_RUN_PATH"
+echo "Starting Cosmic"
+mvn -pl :cloud-client-ui jetty:run > jetty.log 2>&1 &
+
+# Wait until it comes up
+echo "Waiting for Cosmic to start"
+while ! timeout 1 bash -c 'cat < /dev/null > /dev/tcp/localhost/8096' 2>&1 > /dev/null; do echo "Waiting for Mgt server to start.."; sleep 10; done
+
+# Systemvm template for hypervisor type
+if [[ "${hypervisor}" == "kvm" ]]; then
+  systemtemplate="/data/templates/systemvm64template-master-4.6.0-kvm.qcow2"
+  imagetype="qcow2"
+ elif [[ "${hypervisor}" == "xenserver" ]]; then
+  systemtemplate="/data/templates/systemvm64template-master-4.6.0-xen.vhd"
+  imagetype="vhd"
+fi
+
+echo "Install systemvm template.."
+# Consider using -f and point to local cached file
+date
+bash -x ./scripts/storage/secondary/cloud-install-sys-tmplt -m ${secondarystorage} -f ${systemtemplate} -h ${hypervisor} -o localhost -r root -e ${imagetype} -F
+date
+
+echo "Deleting old Marvin logs, if any"
+rm -rf /tmp/MarvinLogs
+
+echo "Deploy data center.."
+python $COSMIC_RUN_PATH/tools/marvin/marvin/deployDataCenter.py -i ${marvinCfg}
+if [ $? -ne 0 ]; then
+  date
+  echo "Deployment failed, please investigate!"
+  exit 1
+fi
+
+# Wait until templates are ready
+date
+echo "Checking template status.."
+python /data/shared/helper_scripts/cosmic/wait_template_ready.py
+date
+
+# Run the tests
+if [ ${run_tests} -eq 1 ]; then
+  echo "Running Marvin tests.."
+  bash -x /data/shared/helper_scripts/cosmic/run_marvin_router_tests.sh ${marvinCfg}
+else
+  echo "Not running tests (use -t flag to run them)"
+fi
+
+echo "Finished"
+date

--- a/helper_scripts/cosmic/check-pr.sh
+++ b/helper_scripts/cosmic/check-pr.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# This script checks out a PR branch and then starts a management server with that code. 
+# Next, you can run Marvin to setup whatever you need to verify the PR.
+
+function usage {
+  printf "Usage: %s: -m marvinCfg -p <pr id> [ -b <branch: default to master> -s <skip compile> -t <run tests> -T <mvn -T flag> ]\n" $(basename $0) >&2
+}
+
+# Options
+skip=
+run_tests=
+compile_threads=
+while getopts 'm:p:T:b:st' OPTION
+do
+  case $OPTION in
+  m)    marvinCfg="$OPTARG"
+        ;;
+  p)    prId="$OPTARG"
+        ;;
+  s)    skip="-s"
+        ;;
+  t)    run_tests="-t"
+        ;;
+  T)    compile_threads="-T $OPTARG"
+        ;;
+  b)    branch_name="$OPTARG"
+        ;;
+  esac
+done
+
+echo "Received arguments:"
+echo "skip = ${skip}"
+echo "run_tests = ${run_tests}"
+echo "marvinCfg = ${marvinCfg}"
+echo "prId = ${prId}"
+echo "compile_threads = ${compile_threads}"
+echo "branch_name = ${branch_name}"
+
+# Check if a marvin dc file was specified
+if [ -z ${marvinCfg} ]; then
+  echo "No Marvin config specified. Quiting."
+  usage
+  exit 1
+else
+  echo "Using Marvin config '${marvinCfg}'."
+fi
+
+if [ ! -f "${marvinCfg}" ]; then
+    echo "Supplied Marvin config not found!"
+    exit 1
+fi
+
+# Default to master branch
+if [ -z "${branch_name}" ]; then
+    branch_name="master"
+    echo "branch_name = ${branch_name}"
+fi
+
+echo "Started!"
+date
+
+# Check if a pull request id was specified
+if [ -z ${prId} ]; then
+  echo "No PR number specified. Quiting."
+  usage
+  exit 1
+fi
+
+# Check if a marvin dc file was specified
+if [ -z ${marvinCfg} ]; then
+  echo "No Marvin config specified. Quiting."
+  usage
+  exit 1
+fi
+
+# Perpare, checkout and stuff
+/data/shared/helper_scripts/cosmic/prepare_cosmic_compile.sh
+
+COSMIC_BUILD_PATH=/data/git/$HOSTNAME/cosmic
+# Go the the source
+cd $COSMIC_BUILD_PATH
+git pull
+git reset --hard
+git checkout ${branch_name}
+git branch --set-upstream-to=origin/${branch_name} ${branch_name}
+git pull --rebase
+
+# Get the PR
+git branch -D pr/${prId}
+git fetch origin pull/${prId}/head:pr/${prId}
+if [ $? -gt 0  ]; then
+  echo "ERROR: Fetching failed!"
+  exit 1
+fi
+git checkout pr/${prId}
+if [ $? -gt 0  ]; then
+  echo "ERROR: Checkout failed!"
+  exit 1
+fi
+
+# Rebase with current ${branch_name} before tests
+git rebase ${branch_name}
+if [ $? -gt 0  ]; then
+  echo "ERROR: Rebase with ${branch_name} failed, please ask author to rebase and force-push commits. Then try again!"
+  exit 1
+fi
+
+# Build, run and test it
+/data/shared/helper_scripts/cosmic/build_run_deploy_test.sh -m ${marvinCfg} ${run_tests} ${skip} ${compile_threads}

--- a/helper_scripts/cosmic/checkout-pr.sh
+++ b/helper_scripts/cosmic/checkout-pr.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script checks out a PR branch and then starts a management server with that code. 
+# Next, you can run Marvin to setup whatever you need to verify the PR.
+
+# Stop executing when we encounter errors
+set -e
+
+# Check if a pull request id was specified
+prId=$1
+if [ -z ${prId} ]; then
+  echo "No PR number specified. Quiting."
+  exit 1
+fi
+
+# Go the the source
+COSMIC_BUILD_PATH=/data/git/$HOSTNAME/cosmic
+cd $COSMIC_BUILD_PATH
+git checkout master
+
+# Get the PR
+git fetch origin pull/${prId}/head:pr/${prId}
+git checkout pr/${prId}

--- a/helper_scripts/cosmic/install_systemvm_s3_template.sh
+++ b/helper_scripts/cosmic/install_systemvm_s3_template.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Use the s3 template at: mcct-nl1.s3.storage.acc.schubergphilis.com
+# For now it's a KVM systemvm template.
+
+templateId=$(mysql -P 3306 -h localhost --user=root --password= --skip-column-names -U cloud -e 'select max(id) from cloud.vm_template where type = "SYSTEM" and hypervisor_type = "KVM" and removed is null')
+
+mysql -P 3306 -h localhost --user=root --password= --skip-column-names -U cloud -e 'update cloud.vm_template set uuid="11f3b47b-78ba-4469-8f7d-c85e205b452c", url="" where id="${templateId}"'

--- a/helper_scripts/cosmic/package44_wrapper.sh
+++ b/helper_scripts/cosmic/package44_wrapper.sh
@@ -1,0 +1,6 @@
+COSMIC_RUN_PATH=/data/git/$HOSTNAME/cosmic/cosmic-core
+cd $COSMIC_RUN_PATH/packaging
+./package.sh -d centos7
+cd $COSMIC_RUN_PATH/dist/rpmbuild/RPMS/x86_64
+echo "Here they are:"
+ls -la

--- a/helper_scripts/cosmic/package45_wrapper.sh
+++ b/helper_scripts/cosmic/package45_wrapper.sh
@@ -1,0 +1,6 @@
+COSMIC_RUN_PATH=/data/git/$HOSTNAME/cosmic/cosmic-core
+cd $COSMIC_RUN_PATH/packaging/centos63
+./package.sh -o rhel7
+cd ../../dist/rpmbuild/RPMS/x86_64
+echo "Here they are:"
+ls -la

--- a/helper_scripts/cosmic/prepare_cosmic_compile.sh
+++ b/helper_scripts/cosmic/prepare_cosmic_compile.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Script to prepare source for Cosmic compile
+
+# Get source
+BASEDIR=/data/git/${HOSTNAME}
+MYDIR=$(pwd -P)
+
+install_pkg() {
+	NAME=$*
+	yum install -y ${NAME}
+	if [ "$?" -ne "0" ]
+	then
+		echo Package Installation Failed exiting
+		exit 1
+	fi
+}
+
+mkdir -p ${BASEDIR}
+cd ${BASEDIR}
+if [ ! -d "cosmic/.git" ]; then
+  echo "No git repo found, cloning Cosmic"
+  git clone --recursive git@github.com:MissionCriticalCloud/cosmic.git
+  echo "Please use 'git checkout' to checkout the branch you need."
+else
+  echo "Git Cosmic repo already found"
+fi
+
+COSMIC_BUILD_PATH=/data/git/$HOSTNAME/cosmic
+cd $COSMIC_BUILD_PATH
+
+# Check VHD-UTIL
+if [ ! -f "scripts/vm/hypervisor/xenserver/vhd-util" ]; then
+  echo "Fetching vhd-util.."
+  cd cosmic-core/scripts/vm/hypervisor/xenserver
+  wget http://download.cloud.com.s3.amazonaws.com/tools/vhd-util
+  cd $COSMIC_BUILD_PATH
+fi
+
+# Set MVN compile options
+export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=512m -Xdebug -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n -Djava.net.preferIPv4Stack=true"
+pwd
+echo "Done."

--- a/helper_scripts/cosmic/run_marvin_router_tests.sh
+++ b/helper_scripts/cosmic/run_marvin_router_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -x
+
+# Check if a marvin dc file was specified
+marvinCfg=$1
+if [ -z ${marvinCfg} ]; then
+  echo "No Marvin config specified. Quiting."
+  exit 1
+fi
+
+COSMIC_BUILD_PATH=/data/git/$HOSTNAME/cosmic
+COSMIC_RUN_PATH=$COSMIC_BUILD_PATH/cosmic-core
+
+# Go the the source
+cd $COSMIC_RUN_PATH/test/integration
+
+echo "Running tests with required_hardware=true"
+nosetests --with-marvin --marvin-config=${marvinCfg} -s -a tags=advanced,required_hardware=true \
+smoke/test_password_server.py \
+smoke/test_vpc_redundant.py \
+smoke/test_routers_iptables_default_policy.py \
+smoke/test_routers_network_ops.py \
+smoke/test_vpc_router_nics.py \
+smoke/test_router_dhcphosts.py \
+smoke/test_loadbalance.py \
+smoke/test_internal_lb.py \
+smoke/test_ssvm.py \
+smoke/test_vpc_vpn.py \
+smoke/test_privategw_acl.py \
+smoke/test_network.py
+
+
+echo "Running tests with required_hardware=false"
+nosetests --with-marvin --marvin-config=${marvinCfg} -s -a tags=advanced,required_hardware=false \
+smoke/test_routers.py \
+smoke/test_network_acl.py \
+smoke/test_reset_vm_on_reboot.py \
+smoke/test_vm_life_cycle.py \
+smoke/test_service_offerings.py \
+smoke/test_network.py \
+component/test_vpc_offerings.py \
+component/test_vpc_routers.py
+

--- a/helper_scripts/cosmic/setup_cloudstackOps.sh
+++ b/helper_scripts/cosmic/setup_cloudstackOps.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+BASEDIR=/data/git/${HOSTNAME}
+
+mkdir -p ${BASEDIR}
+cd ${BASEDIR}
+
+# Setup and clone
+if [ ! -d "cloudstackOps/.git" ]; then
+  git clone https://github.com/remibergsma/cloudstackOps.git
+  cd cloudstackOps
+  cp -pr config.sample config
+else
+  echo "CloudstackOps clone already available."
+fi
+if [ ! -d "${BASEDIR}/python_cloud" ]; then
+  echo "Setting up virtualenv.."
+  sudo yum -y install python-virtualenv
+  virtualenv ${BASEDIR}/python_cloud
+  source ${BASEDIR}/python_cloud/bin/activate
+  pip install mysql-connector-python --allow-external mysql-connector-python requests
+  pip install -Iv ${BASEDIR}/cloudstackOps/marvin/Marvin-0.1.0.tar.gz
+  pip install prettytable clint
+fi
+
+# Feed API keys to CloudMonkey config
+echo "Setting up API keys to ${BASEDIR}/cloudstackOps/config"
+cloudmonkey set display default
+APIKEY=$(cloudmonkey list accounts name=admin | grep 'apikey' | awk {'print $3'})
+SECRETKEY=$(cloudmonkey list accounts name=admin | grep 'secretkey' | awk {'print $3'})
+sed -i "/apikey/c\apikey = $APIKEY" ${BASEDIR}/cloudstackOps/config
+sed -i "/secretkey/c\secretkey = $SECRETKEY" ${BASEDIR}/cloudstackOps/config
+sed -i "/url/c\url = http://cs1.cloud.lan:8080/client/api" ${BASEDIR}/cloudstackOps/config
+echo "Done. To get started:"
+echo
+echo " source ${BASEDIR}/python_cloud/bin/activate" 
+echo " cd ${BASEDIR}/cloudstackOps"
+echo " python listVirtualMachines.py -o MCCT-XEN-1"

--- a/helper_scripts/cosmic/wait_template_ready.py
+++ b/helper_scripts/cosmic/wait_template_ready.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+
+# Wait unil templates are ready
+
+import urllib2
+import sys
+import json
+import time
+import os.path
+import getopt
+
+class Templates():
+
+    def __init__(self, argv):
+        self.target = None
+        self.handleArguments(argv)
+
+    # Handle the arguments
+    def handleArguments(self, argv):
+        # Usage message
+        help = "Usage: ./" + os.path.basename(__file__) + " [options]" + \
+            "\n  --target -t \t\tManagement Server host (default 'localhost')"
+
+        try:
+            opts, args = getopt.getopt(
+                argv, "ht:", ["target="])
+        except getopt.GetoptError as e:
+            print "Error: " + str(e)
+            print help
+            sys.exit(2)
+
+        for opt, arg in opts:
+            print "processing option " + opt + " arg " + arg
+            if opt == "-h":
+                print help
+                sys.exit()
+            elif opt in ("-t", "--target"):
+                self.target = arg
+
+        if self.target is None:
+            self.target = "localhost"
+
+    def list_templates(self):
+        url = "http://" + self.target + ":8096/client/api?command=listTemplates&templatefilter=all&response=json"
+        print url
+        response = urllib2.urlopen(url)
+        return response.read()
+
+    def print_templates(self):
+        templates = self.list_templates()
+        print templates
+
+    def get_json(self):
+        templates = self.list_templates()
+        data = json.loads(templates)['listtemplatesresponse']['template']
+        return data
+
+    def templates_ready(self):
+        templates = self.get_json()
+        for t in templates:
+            if t is None:
+                continue
+            if t['isready'] != True:
+                print time.strftime("%c") + " At least template '" + t['name'] + "' is not Ready"
+                return False
+        return True
+
+    def wait_ready(self):
+        while True:
+            if self.templates_ready() == True:
+                print time.strftime("%c") + " All templates are ready!"
+                return True
+            else:
+                time.sleep(15)
+
+t = Templates(sys.argv[1:])
+print t.wait_ready()


### PR DESCRIPTION
- Copies the ACS ones replacing claudstack by cosmic[-core]

I tested the following scripts:
- ./build_run.sh 
- ./package44_wrapper.sh 
- ./run_marvin_router_tests.sh 

Concerning the check-pr scripts, we have to discuss about the `git fetch origin pull/${prId}/head:pr/${prId}` command with the submodules.
