### PR TITLE
Newer openvswitch version to support CentOS 7.2 and STT

### DIFF
--- a/deploy/firstboot/centos7-kvm-ovs.sh
+++ b/deploy/firstboot/centos7-kvm-ovs.sh
@@ -69,8 +69,8 @@ new-kernel-pkg --mkinitrd --install `uname -r`
 # Rename builtin openvswitch module, add custom OVS package with STT support and start it
 mv "/lib/modules/$(uname -r)/kernel/net/openvswitch/openvswitch.ko" "/lib/modules/$(uname -r)/kernel/net/openvswitch/openvswitch.org"
 yum -y install "kernel-devel-$(uname -r)"
-yum -y install http://mctadm1/openvswitch/openvswitch-dkms-2.4.1-1.el7.centos.x86_64.rpm
-yum -y install http://mctadm1/openvswitch/openvswitch-2.4.1-1.el7.centos.x86_64.rpm
+yum -y install http://mctadm1/openvswitch/openvswitch-dkms-2.5.90-1.el7.centos.x86_64.rpm
+yum -y install http://mctadm1/openvswitch/openvswitch-2.5.90-1.el7.centos.x86_64.rpm
 
 # Bridges
 systemctl start openvswitch


### PR DESCRIPTION
The kernel of CentOS 7.2 does not compile openvswitch 2.4.1, which is needed to support STT encapsulation. Openvswitch master branch  (2.5.90) compiles and works as expected. Script has been updated to use the newer version
