### PR TITLE
Fix path to script installing system template

### DIFF
--- a/helper_scripts/cosmic/build_run_deploy_test.sh
+++ b/helper_scripts/cosmic/build_run_deploy_test.sh
@@ -375,7 +375,7 @@ fi
 echo "Install systemvm template.."
 # Consider using -f and point to local cached file
 date
-bash -x ./scripts/storage/secondary/cloud-install-sys-tmplt -m ${secondarystorage} -f ${systemtemplate} -h ${hypervisor} -o localhost -r root -e ${imagetype} -F
+bash -x $COSMIC_RUN_PATH/scripts/storage/secondary/cloud-install-sys-tmplt -m ${secondarystorage} -f ${systemtemplate} -h ${hypervisor} -o localhost -r root -e ${imagetype} -F
 date
 
 echo "Deleting old Marvin logs, if any"


### PR DESCRIPTION
Before:

```
Install systemvm template..
Fri Feb  5 10:59:38 GMT 2016
bash: ./scripts/storage/secondary/cloud-install-sys-tmplt: No such file or directory
Fri Feb  5 10:59:38 GMT 2016
Deleting old Marvin logs, if any
```

After:

```
Successfully installed system VM template /data/templates/systemvm64template-master-4.6.0-kvm.qcow2 to /data/storage/secondary/MCCT-SHARED-1/template/tmpl/1/3/
Fri Feb  5 12:45:26 GMT 2016
Deleting old Marvin logs, if any
```
