### PR TITLE
Wait for NSX controller to be ready

### DIFF
--- a/deploy/postboot/post_nsx_controller.sh
+++ b/deploy/postboot/post_nsx_controller.sh
@@ -4,6 +4,12 @@ NSX_CONTROLLER=$1
 # We get this passed from the main script
 NEWHOST=$2
 
+echo "Note: Waiting for the VM to boot..."
+# Wait until the VM is alive
+while ! ping -c1 ${NEWHOST} &>/dev/null; do :; done
+echo "Note: Ping result for ${NEWHOST}"
+ping -c1 ${NEWHOST}
+
 NSX_CONTROLLER_IP=$(getent hosts ${NSX_CONTROLLER} | awk '{ print $1 }')
 
 SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"


### PR DESCRIPTION
Usually deployment of NSX (vm) is fast enough to be ready.
Ensure that the script will not break if it does take longer.
Note the:

```
Note: Waiting for the VM to boot...
Note: Ping result for nsxcon2
PING nsxcon2.cloud.lan (192.168.22.84) 56(84) bytes of data.
64 bytes from nsxcon2.cloud.lan (192.168.22.84): icmp_seq=1 ttl=64 time=0.105 ms

--- nsxcon2.cloud.lan ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.105/0.105/0.105/0.000 ms
```

in this "test":

```
Note: You want to deploy a VM with role 'nsx-controller-cluster1'..
Note: VM name nsxcon1 is already in use
Note: VM name nsxcon2 is available
WARNING: nsxcon2: No firstboot script defined.
Note: nsxcon2: Running postboot script: /data/shared/deploy/postboot/post_nsx_controller.sh nsxcon1 nsxcon2
Note: Waiting for the VM to boot...
Note: Ping result for nsxcon2
PING nsxcon2.cloud.lan (192.168.22.84) 56(84) bytes of data.
64 bytes from nsxcon2.cloud.lan (192.168.22.84): icmp_seq=1 ttl=64 time=0.105 ms

--- nsxcon2.cloud.lan ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.105/0.105/0.105/0.000 ms
Package sshpass-1.05-5.el7.x86_64 already installed and latest version
Joining cluster
Warning: Permanently added 'nsxcon2,192.168.22.84' (ECDSA) to the list of known hosts.
Stopping nicira-nvp-controller: [Done]
Clearing nicira-nvp-controller's state: OK
Starting nicira-nvp-controller: CLI revert file already exists
ssh stop/waiting
ssh start/running, process 2597
ssh stop/waiting
mapping eth0 -> bridged-pif
mapping breth0 -> eth0
mapping breth0 -> eth0
ssh start/running, process 2768
Setting core limit to unlimited
Setting file descriptor limit to 100000
WARNING: Logging before InitGoogleLogging() is written to STDERR
D0209 14:31:07.134882  2891 info-file.cc:23] Created a InfoFile object for info_file: /var/cloudnet/data/controllerd.info
 nicira-nvp-controller [OK]
Clearing controller state and restarting
** Watching control-cluster history; ctrl-c to exit **
===================================
Host nsx-controller
Node 8fa10a0d-04dc-4e07-8dd3-4b0a305709d0 (192.168.22.84)
  ---------------------------------
  02/09 14:31:08: Joining cluster via node 192.168.22.83
  02/09 14:31:08: Waiting to join cluster
  02/09 14:31:08: Joined cluster; initializing local components
  02/09 14:31:20: Initializing data contact with cluster
  02/09 14:31:20: Fetching initial configuration data
  02/09 14:31:22: Join complete
```
