### PR TITLE
Use kvm_local_deploy.py to destroy VMs

### DIFF
--- a/ci/ci-cleanup.sh
+++ b/ci/ci-cleanup.sh
@@ -26,7 +26,7 @@ function collect_files_from_vm {
 function destroy_vm {
   vmname=$1
 
-  /data/vm-easy-deploy/remove_vm.sh -f ${vmname}
+  /data/shared/deploy/kvm_local_deploy.py -x ${vmname}
 }
 
 


### PR DESCRIPTION
This should have bene fixed in pr #86, but somehow it regressed and needs to be applied again.

Build using this script is running here: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic-dev/job/collect-artifacts-and-cleanup/7/
