### PR TITLE
cd to cosmic-core directory when installing Marvin

### DIFF
--- a/helper_scripts/cosmic/build_run_deploy_test.sh
+++ b/helper_scripts/cosmic/build_run_deploy_test.sh
@@ -157,11 +157,12 @@ elif [[ "$hypervisor" == "xenserver" ]]; then
     fi
 fi
 
+cd "$COSMIC_CORE_PATH"
+
 # Install Marvin
 echo "Installing Marvin"
 pip install --upgrade tools/marvin/dist/Marvin-*.tar.gz --allow-external mysql-connector-python
 
-cd "$COSMIC_CORE_PATH"
 # Deploy DB
 echo "Deploying Cosmic DB"
 mvn -P developer -pl developer -Ddeploydb -T 4


### PR DESCRIPTION
Otherwise it will throw a file not found exception, due to it expecting marvin to be in: tools/marvin/dist/Marvin-*.tar.gz
