### PR TITLE
Warn CloudStack users for Java8

### DIFF
--- a/helper_scripts/cloudstack/build_run_deploy_test.sh
+++ b/helper_scripts/cloudstack/build_run_deploy_test.sh
@@ -49,6 +49,29 @@ fi
 echo "Started!"
 date
 
+JAVA_VERSION_FOUND=$(java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}' | cut -d\. -f1,2)
+
+if [ "$JAVA_VERSION_FOUND" == "1.8" ]; then
+  echo
+  echo "*** WARNING: JAVA 8 FOUND! ***"
+  echo
+  echo "The active Java version is compatible with Cosmic, not with CloudStack."
+  echo
+  echo "CloudStack does not run on Java 8 yet. Since The Bubbles are also used for Cosmic, it has Java 8."
+  echo
+  echo "Run this to deinstall Java 8 and use Java 7:"
+
+  for j in $(rpm -qa| grep java-1.8); do echo " yum remove $j"; done
+  echo 
+  echo "You may also switch Java with:"
+  echo " alternatives --config java"
+  echo " alternatives --config javac"
+  echo
+  echo "In case you want to build Cosmic, look in the 'helper_scripts/cosmic' folder."
+  echo
+  exit
+fi
+
 # Find ip
 host_ip=`ip addr | grep 'inet 192' | cut -d: -f2 | awk '{ print $2 }' | awk -F\/24 '{ print $1 }'`
 


### PR DESCRIPTION
The version of `build_run_deploy_test.sh` in the `helper_scripts/cloudstack` folder is used by CloudStack users that will encounter problems as CloudStack doesn't work with Java 8.

A simple warning message will be displayed. The Cosmic version is not changed.

![screen shot 2016-04-09 at 16 23 29 pm](https://cloud.githubusercontent.com/assets/1630096/14404130/a49896cc-fe6f-11e5-9d6a-75678991855f.png)

Ping @swill @DaanHoogland 
