### PR TITLE
Only run tests that require hardware

### DIFF
--- a/helper_scripts/cosmic/run_marvin_router_tests.sh
+++ b/helper_scripts/cosmic/run_marvin_router_tests.sh
@@ -29,16 +29,3 @@ smoke/test_ssvm.py \
 smoke/test_vpc_vpn.py \
 smoke/test_privategw_acl.py \
 smoke/test_network.py
-
-
-echo "Running tests with required_hardware=false"
-nosetests --with-marvin --marvin-config=${marvinCfg} -s -a tags=advanced,required_hardware=false \
-smoke/test_routers.py \
-smoke/test_network_acl.py \
-smoke/test_reset_vm_on_reboot.py \
-smoke/test_vm_life_cycle.py \
-smoke/test_service_offerings.py \
-smoke/test_network.py \
-component/test_vpc_offerings.py \
-component/test_vpc_routers.py
-


### PR DESCRIPTION
The others always pass and are a waste of time. Already removed from Jenkins.
