### PR TITLE
added support for java 7 as a cloudstack management role

### DIFF
--- a/deploy/firstboot/centos7-cloudstack-java7.sh
+++ b/deploy/firstboot/centos7-cloudstack-java7.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Prepare CentOS7 bare box to compile CloudStack and run management server
+sleep 5
+
+# Disable mirrorlist in yum
+sed -i '/mirrorlist/s/^/#/' /etc/yum.repos.d/*.repo
+sed -i 's/#baseurl/baseurl/' /etc/yum.repos.d/*.repo
+
+yum -y install maven tomcat mkisofs python-paramiko jakarta-commons-daemon-jsvc jsvc ws-commons-util genisoimage gcc python MySQL-python openssh-clients wget git python-ecdsa bzip2 python-setuptools mariadb-server mariadb python-devel vim nfs-utils screen setroubleshoot openssh-askpass java-1.7.0-openjdk-devel.x86_64 rpm-build rubygems nc
+yum -y install http://mirror.karneval.cz/pub/linux/fedora/epel/epel-release-latest-7.noarch.rpm
+yum --enablerepo=epel -y install sshpass mariadb mysql-connector-python
+
+echo "JAVA_OPTS=\"-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms1536m -Xmx3584m -XX:MaxPermSize=256M\"" >> ~tomcat/conf/tomcat.conf
+systemctl restart tomcat.service
+
+echo "max_allowed_packet=64M" >> /etc/my.cnf
+systemctl start mariadb.service
+systemctl enable mariadb.service
+
+systemctl stop firewalld.service
+systemctl disable firewalld.service
+
+mkdir -p /data
+mount -t nfs 192.168.22.1:/data /data
+echo "192.168.22.1:/data /data nfs rw,hard,intr,rsize=8192,wsize=8192,timeo=14 0 0" >> /etc/fstab
+
+mkdir -p /data/git
+cd /data/git
+cd /root
+
+wget https://raw.githubusercontent.com/remibergsma/dotfiles/master/.screenrc
+
+curl "https://bootstrap.pypa.io/get-pip.py" | python
+pip install cloudmonkey
+
+easy_install nose
+easy_install pycrypto
+
+timedatectl set-timezone CET
+
+# Reboot
+reboot

--- a/deploy/role/cloudstack-mgt-java7.conf
+++ b/deploy/role/cloudstack-mgt-java7.conf
@@ -1,0 +1,11 @@
+[role]
+rolename = cloudstack-mgt-java7
+vm_prefix = cs
+offering = medium
+hardware = generic
+net_model = virtio
+disk_dev = vda
+disk_bus = virtio
+image = centos7
+firstboot = centos7-cloudstack-java7.sh
+postboot = post_detect_reboot.sh


### PR DESCRIPTION
This creates another role which can be used specifically for ACS which does not support Java 8.

I have tested this role by spinning up a new environment with it:

```
./kvm_local_deploy.py -r cloudstack-mgt-java7 && ./kvm_local_deploy.py -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg
```

And running a basic set of tests against it to prove that management server is functional.

```
# cat /tmp/MarvinLogs/test_network_9PJ3CT/results.txt 
Test for port forwarding on source NAT ... === TestName: test_01_port_fwd_on_src_nat | Status : SUCCESS ===
ok
Test for port forwarding on non source NAT ... === TestName: test_02_port_fwd_on_non_src_nat | Status : SUCCESS ===
ok
Test for reboot router ... === TestName: test_reboot_router | Status : SUCCESS ===
ok
Test for Router rules for network rules on acquired public IP ... === TestName: test_network_rules_acquired_public_ip_1_static_nat_rule | Status : SUCCESS ===
ok
Test for Router rules for network rules on acquired public IP ... === TestName: test_network_rules_acquired_public_ip_2_nat_rule | Status : SUCCESS ===
ok
Test for Router rules for network rules on acquired public IP ... === TestName: test_network_rules_acquired_public_ip_3_Load_Balancer_Rule | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 6 tests in 749.785s

OK
```
