### PR TITLE
Adds the ability to specify which test file to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Example:
  ./check-pr.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg -p 1348 -b 4.8 -t
 ```
 
+If you want to run your own tests, you can specify the `-f test_file_name.sh` flag.  
+If you don't specify a test file with the `-f` flag, it will automatically default to the following test scenario:
+```
+ ./check-pr.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg -p 1348 -b 4.8 -t -f run_marvin_router_tests.sh
+```
+This will run the tests defined in the `/data/share/helper_scripts/cloudstack/run_marvin_router_tests.sh` file.
+
 ### Results of a test:
 
 ![screen shot 2016-01-20 at 11 29 42](https://cloud.githubusercontent.com/assets/1630096/12446309/9433e286-bf69-11e5-8906-77bfeca86dea.png)

--- a/helper_scripts/cloudstack/build_run_deploy_test.sh
+++ b/helper_scripts/cloudstack/build_run_deploy_test.sh
@@ -423,13 +423,13 @@ if [ ${run_tests} -eq 1 ]; then
   echo "Running Marvin tests.."
   if [ -z ${test_file} ]; then
     # for backwards compatibility, default to 'run_marvin_router_tests.sh' if test file is not specified
-    test_file="run_marvin_router_tests.sh"
+    test_file="/data/shared/helper_scripts/cloudstack/run_marvin_router_tests.sh"
   fi
-  if [ -f "/data/shared/helper_scripts/cloudstack/${test_file}" ]; then
-    # found the specified test file, continue with test execution
-    bash -x /data/shared/helper_scripts/cloudstack/${test_file} ${marvinCfg}
+  if [ -f "${test_file}" ]; then
+    # the test file exists, so run the tests...
+    bash -x ${test_file} ${marvinCfg}
   else
-    echo "The specified test file does not exist!  Verify the file path: /data/shared/helper_scripts/cloudstack/${test_file}"
+    echo "The specified test file does not exist!  Verify the file path: ${test_file}"
   fi
 else
   echo "Not running tests (use the -t flag to run them, and optionally, -f to specify which file to run)"

--- a/helper_scripts/cloudstack/build_run_deploy_test.sh
+++ b/helper_scripts/cloudstack/build_run_deploy_test.sh
@@ -5,14 +5,15 @@
 # When done, it runs the desired tests.
 
 function usage {
-  printf "Usage: %s: -m marvinCfg [ -s <skip compile> -t <run tests> -T <mvn -T flag> ]\n" $(basename $0) >&2
+  printf "Usage: %s: -m marvinCfg [ -s <skip compile> -t <run tests> -f <test file to run> -T <mvn -T flag> ]\n" $(basename $0) >&2
 }
 
 # Options
 skip=0
 run_tests=0
+test_file=
 compile_threads=
-while getopts 'm:T:st' OPTION
+while getopts 'm:T:f:st' OPTION
 do
   case $OPTION in
   m)    marvinCfg="$OPTARG"
@@ -20,6 +21,8 @@ do
   s)    skip=1
         ;;
   t)    run_tests=1
+        ;;
+  f)    test_file="$OPTARG"
         ;;
   T)    compile_threads="-T $OPTARG"
         ;;
@@ -29,6 +32,7 @@ done
 echo "Received arguments:"
 echo "skip = ${skip}"
 echo "run_tests = ${run_tests}"
+echo "test_file = ${test_file}"
 echo "marvinCfg = ${marvinCfg}"
 echo "compile_threads = ${compile_threads}"
 
@@ -417,9 +421,18 @@ date
 # Run the tests
 if [ ${run_tests} -eq 1 ]; then
   echo "Running Marvin tests.."
-  bash -x /data/shared/helper_scripts/cloudstack/run_marvin_router_tests.sh ${marvinCfg}
+  if [ -z ${test_file} ]; then
+    # for backwards compatibility, default to 'run_marvin_router_tests.sh' if test file is not specified
+    test_file="run_marvin_router_tests.sh"
+  fi
+  if [ -f "/data/shared/helper_scripts/cloudstack/${test_file}" ]; then
+    # found the specified test file, continue with test execution
+    bash -x /data/shared/helper_scripts/cloudstack/${test_file} ${marvinCfg}
+  else
+    echo "The specified test file does not exist!  Verify the file path: /data/shared/helper_scripts/cloudstack/${test_file}"
+  fi
 else
-  echo "Not running tests (use -t flag to run them)"
+  echo "Not running tests (use the -t flag to run them, and optionally, -f to specify which file to run)"
 fi
 
 echo "Finished"

--- a/helper_scripts/cloudstack/check-pr.sh
+++ b/helper_scripts/cloudstack/check-pr.sh
@@ -4,14 +4,15 @@
 # Next, you can run Marvin to setup whatever you need to verify the PR.
 
 function usage {
-  printf "Usage: %s: -m marvinCfg -p <pr id> [ -b <branch: default to master> -s <skip compile> -t <run tests> -T <mvn -T flag> ]\n" $(basename $0) >&2
+  printf "Usage: %s: -m marvinCfg -p <pr id> [ -b <branch: default to master> -s <skip compile> -t <run tests> -f <test file to run> -T <mvn -T flag> ]\n" $(basename $0) >&2
 }
 
 # Options
 skip=
 run_tests=
+test_file=
 compile_threads=
-while getopts 'm:p:T:b:st' OPTION
+while getopts 'm:p:T:b:f:st' OPTION
 do
   case $OPTION in
   m)    marvinCfg="$OPTARG"
@@ -21,6 +22,8 @@ do
   s)    skip="-s"
         ;;
   t)    run_tests="-t"
+        ;;
+  f)    test_file="-f $OPTARG"
         ;;
   T)    compile_threads="-T $OPTARG"
         ;;
@@ -32,6 +35,7 @@ done
 echo "Received arguments:"
 echo "skip = ${skip}"
 echo "run_tests = ${run_tests}"
+echo "test_file = ${test_file}"
 echo "marvinCfg = ${marvinCfg}"
 echo "prId = ${prId}"
 echo "compile_threads = ${compile_threads}"
@@ -96,4 +100,4 @@ if [ $? -gt 0  ]; then
 fi
 
 # Build, run and test it
-/data/shared/helper_scripts/cloudstack/build_run_deploy_test.sh -m ${marvinCfg} ${run_tests} ${skip} ${compile_threads}
+/data/shared/helper_scripts/cloudstack/build_run_deploy_test.sh -m ${marvinCfg} ${run_tests} ${test_file} ${skip} ${compile_threads}


### PR DESCRIPTION
This PR adds the ability to specify an optional `-f test_file_name.sh` flag to either `check-pr.sh` or `build_run_deploy_test.sh` to specify which test file will be run.

Assuming a test file exists at `/data/share/helper_scripts/cloudstack/run_marvin_alternate_tests.sh`, it can be targeted while doing a `./check-pr.sh` with the following:

```
./check-pr.sh -m /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg -p 1348 -b 4.8 -t -f run_marvin_alternate_tests.sh
```

This PR is completely backwards compatible, so if you do not specify a file with `-f` it will default to the previously configured `run_marvin_router_tests.sh` file.

I have also added documentation to the `README` so people know this option exists.
