### PR TITLE
Fix bridge names in KVM for CloudStack usage

### DIFF
--- a/helper_scripts/cloudstack/build_run_deploy_test.sh
+++ b/helper_scripts/cloudstack/build_run_deploy_test.sh
@@ -355,6 +355,10 @@ mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, 
 mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'network.gc.wait', '10') ON DUPLICATE KEY UPDATE value = '10';"
 # Number of VPC tiers (as required by smoke/test_privategw_acl.py)
 mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'vpc.max.networks', '4') ON DUPLICATE KEY UPDATE value = '4';"
+# KVM  bridges
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'kvm.private.network.device', 'cloudbr1') ON DUPLICATE KEY UPDATE value = 'cloudbr1';"
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'kvm.public.network.device', 'cloudbr0') ON DUPLICATE KEY UPDATE value = 'cloudbr0';"
+mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'kvm.guest.network.device', 'cloudbr0') ON DUPLICATE KEY UPDATE value = 'cloudbr0';"
 
 # Adding the right SystemVMs, for both KVM and XenServer
 # Adding the tiny linux VM templates for KVM and XenServer


### PR DESCRIPTION
This fixes an issue for CloudStack users introduced in PR #114 

Ping @swill @borisroman @neubauerf 

Tested on latest ACS master, works fine.

![image](https://cloud.githubusercontent.com/assets/1630096/14858815/d246f998-0ca1-11e6-9f18-6e7db38bd0f3.png)

Bridges look OK and match the config in the marvin json files:

```
    <interface type='bridge'>
      <mac address='0e:00:a9:fe:02:5d'/>
      <source bridge='cloud0'/>
      <target dev='vnet0'/>
      <model type='virtio'/>
      <alias name='net0'/>
      <rom bar='off' file=''/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='06:98:a6:00:00:0b'/>
      <source bridge='cloudbr1'/>
      <target dev='vnet1'/>
      <model type='virtio'/>
      <alias name='net1'/>
      <rom bar='off' file=''/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='06:3d:30:00:00:17'/>
      <source bridge='cloudbr0'/>
      <target dev='vnet2'/>
      <model type='virtio'/>
      <alias name='net2'/>
      <rom bar='off' file=''/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
    </interface>
```
