### PR TITLE
Enable remote debugging for mgt server and KVM agents

### DIFF
--- a/helper_scripts/cosmic/build_run_deploy_test.sh
+++ b/helper_scripts/cosmic/build_run_deploy_test.sh
@@ -191,8 +191,10 @@ while timeout 1 bash -c 'cat < /dev/null > /dev/tcp/localhost/8096' 2>&1 > /dev/
 
 # Start Cosmic Management Server
 cd $COSMIC_BUILD_PATH/cosmic-client
-echo "Starting Cosmic"
-mvn -pl :cloud-client-ui jetty:run > jetty.log 2>&1 &
+echo "Starting Cosmic (debug mode)"
+#mvnDebug sets suspend=y and waits for connection
+#mvnDebug -pl :cloud-client-ui jetty:run > jetty.log 2>&1 &
+/usr/lib/jvm/java/bin/java -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000 -classpath /usr/share/maven/boot/plexus-classworlds.jar -Dclassworlds.conf=/usr/share/maven/bin/m2.conf -Dmaven.home=/usr/share/maven org.codehaus.plexus.classworlds.launcher.Launcher -pl :cloud-client-ui jetty:run > jetty.log 2>&1 &
 
 # Wait until it comes up
 echo "Waiting for Cosmic to start"

--- a/helper_scripts/cosmic/helperlib.sh
+++ b/helper_scripts/cosmic/helperlib.sh
@@ -44,6 +44,10 @@ function install_kvm_packages {
     ${ssh_base} ${hvuser}@${hvip} 'echo "network.bridge.type=openvswitch" >> /etc/cosmic/agent/agent.properties'
     ${ssh_base} ${hvuser}@${hvip} 'echo "guest.cpu.mode=host-model" >> /etc/cosmic/agent/agent.properties'
   fi
+  # Enable remote debugging
+  ${ssh_base} ${hvuser}@${hvip} mkdir -p /etc/systemd/system/cosmic-agent.service.d/
+  ${ssh_base} ${hvuser}@${hvip} 'printf "[Service]\nEnvironment=JAVA_REMOTE_DEBUG=-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000" > /etc/systemd/system/cosmic-agent.service.d/debug.conf'
+  ${ssh_base} ${hvuser}@${hvip} systemctl daemon-reload
 }
 
 function clean_kvm {


### PR DESCRIPTION
When spinning a cloud manually, enable the debug options by default so you can connect with your IDE.

To be used with https://github.com/MissionCriticalCloud/packaging/pull/16
