### PR TITLE
Call Marvin via python -m instead of full path

### DIFF
--- a/helper_scripts/cosmic/build_run_deploy_test.sh
+++ b/helper_scripts/cosmic/build_run_deploy_test.sh
@@ -216,7 +216,7 @@ bash -x $COSMIC_CORE_PATH/scripts/storage/secondary/cloud-install-sys-tmplt -m $
 date
 
 echo "Deploy data center.."
-python $COSMIC_CORE_PATH/tools/marvin/marvin/deployDataCenter.py -i ${marvinCfg}
+python -m marvin.deployDataCenter -i ${marvinCfg}
 if [ $? -ne 0 ]; then
   date
   echo "Deployment failed, please investigate!"


### PR DESCRIPTION
Marvin is no longer in cosmic-core so the path doesn't work. Now it works when Marvin is installed one way or the other.
