### PR TITLE
Build and run Cosmic from the offline source.

### DIFF
--- a/helper_scripts/cosmic/build_run.sh
+++ b/helper_scripts/cosmic/build_run.sh
@@ -15,10 +15,10 @@ config_maven
 
 # Compile Cosmic
 cd $COSMIC_BUILD_PATH
-mvn clean install -P developer,systemvm -T 4
+mvn clean install -P developer,systemvm -T 4 -o
 # Deploy DB
 cd $COSMIC_RUN_PATH
-mvn -P developer -pl developer -Ddeploydb
+mvn -P developer -pl developer -Ddeploydb -o
 # Configure the hostname properly - it doesn't exist if the deployeDB doesn't include devcloud
 mysql -u cloud -pcloud cloud --exec "INSERT INTO cloud.configuration (instance, name, value) VALUE('DEFAULT', 'host', '$host_ip') ON DUPLICATE KEY UPDATE value = '$host_ip';"
 # Insert OVS bridge
@@ -39,4 +39,4 @@ mysql -u cloud -pcloud cloud --exec "UPDATE service_offering SET ha_enabled = 1;
 pip install --upgrade "https://beta-nexus.mcc.schubergphilis.com/service/local/artifact/maven/redirect?r=snapshots&g=cloud.cosmic&a=cloud-marvin&v=LATEST&p=tar.gz" --allow-external mysql-connector-python
 
 # Run mgt
-mvn -pl :cloud-client-ui jetty:run
+mvn -pl :cloud-client-ui jetty:run -o

--- a/helper_scripts/cosmic/build_run_deploy_test.sh
+++ b/helper_scripts/cosmic/build_run_deploy_test.sh
@@ -92,7 +92,7 @@ find /data/git/$HOSTNAME/cosmic/cosmic-client -name \*.gz | xargs rm -f
 config_maven
 
 # Short pre-compile may be needed to solve dependency
-mvn clean install -N
+mvn clean install -N -o
 
 # Compile Cosmic
 if [ ${skip} -eq 0 ]; then
@@ -100,7 +100,7 @@ if [ ${skip} -eq 0 ]; then
   cd "$COSMIC_BUILD_PATH"
   echo "Compiling Cosmic"
   date
-  mvn clean install -P developer,systemvm ${compile_threads}
+  mvn clean install -P developer,systemvm ${compile_threads} -o
   if [ $? -ne 0 ]; then
     date
     echo "Build failed, please investigate!"
@@ -168,7 +168,7 @@ pip install --upgrade "https://beta-nexus.mcc.schubergphilis.com/service/local/a
 
 # Deploy DB
 echo "Deploying Cosmic DB"
-mvn -P developer -pl developer -Ddeploydb -T 4
+mvn -P developer -pl developer -Ddeploydb -T 4 -o
 if [ $? -ne 0 ]; then
   date
   echo "Build failed, please investigate!"


### PR DESCRIPTION
When testing or debug with a remote debugger, we need the same source remote and local. If we not use the --offline (short -o) option we will grab the latest snapshot version from nexus, which might not even be the code we want to test!
