### PR TITLE
Deploy management server from marvin_config

### DIFF
--- a/deploy/default/role/cs.conf
+++ b/deploy/default/role/cs.conf
@@ -1,0 +1,1 @@
+cloudstack-mgt-dev.conf

--- a/deploy/kvm_local_deploy.py
+++ b/deploy/kvm_local_deploy.py
@@ -605,12 +605,22 @@ class kvm_local_deploy:
             hosts.append(url_split[2].split('.')[0])
         return hosts
 
+    # Get hypervisors from Marvin
+    def get_management_hosts(self):
+        hosts = []
+        if not self.marvin_data:
+            self.load_marvin_json()
+        for h in self.marvin_data['mgtSvr']:
+            if 'mgtSvrName' in h:
+                hosts.append(h['mgtSvrName'])
+        return hosts
+
     # Deploy Marvin infra
     def deploy_marvin(self):
         if not self.get_marvin_json():
             return False
         print "Note: Found hypervisor type '" + self.get_hypervisor_type() + "'"
-        hosts = self.get_hosts()
+        hosts = self.get_management_hosts() + self.get_hosts()
         pool = ThreadPool(4)
         results = pool.map(self.deploy_host, hosts)
         pool.close()

--- a/marvin/mct-zone1-kvm1-kvm2-v2.cfg
+++ b/marvin/mct-zone1-kvm1-kvm2-v2.cfg
@@ -1,0 +1,206 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+{
+    "zones": [
+        {
+            "name": "MCCT-SHARED-1",
+            "guestcidraddress": "10.1.1.0/24",
+            "dns1": "8.8.8.8",
+            "physical_networks": [
+                {
+                    "broadcastdomainrange": "Zone",
+                    "vlan": "100-200",
+                    "name": "mcct-pnet",
+                    "traffictypes": [
+                        {
+                            "typ": "Guest"
+                        },
+                        {
+                            "typ": "Management"
+                        },
+                        {
+                            "typ": "Public"
+                        }
+                    ],
+                    "providers": [
+                        {
+                            "broadcastdomainrange": "ZONE",
+                            "name": "VirtualRouter"
+                        },
+                        {
+                            "broadcastdomainrange": "ZONE",
+                            "name": "VpcVirtualRouter"
+                        },
+                        {
+                            "broadcastdomainrange": "ZONE",
+                            "name": "InternalLbVm"
+                        }
+                    ],
+                    "isolationmethods": [
+                             "VLAN"
+                    ]
+                }
+            ],
+            "ipranges": [
+                {
+                    "startip": "192.168.23.2",
+                    "endip": "192.168.23.50",
+                    "netmask": "255.255.255.0",
+                    "gateway": "192.168.23.1"
+                }
+            ],
+            "networktype": "Advanced",
+            "pods": [
+                {
+                    "endip": "192.168.22.150",
+                    "name": "MCCT-POD",
+                    "startip": "192.168.22.130",
+                    "netmask": "255.255.255.0",
+                    "clusters": [
+                    ],
+                    "clusters": [
+                        {
+                            "clustername": "MCCT-KVM-1",
+                            "hypervisor": "KVM",
+                            "hosts": [
+                                {
+                                    "username": "root",
+                                    "url": "http://kvm1",
+                                    "password": "password"
+                                },
+                                {
+                                    "username": "root",
+                                    "url": "http://kvm2",
+                                    "password": "password"
+                                }
+                            ],
+                            "clustertype": "CloudManaged",
+                            "primaryStorages": [
+                                {
+                                    "url": "nfs://192.168.22.1:/data/storage/primary/MCCT-KVM-1",
+                                    "name": "MCCT-KVM-1-primary"
+                                }
+                            ]
+                        }
+                    ],
+                    "gateway": "192.168.22.1"
+                }
+            ],
+            "internaldns1": "8.8.4.4",
+            "secondaryStorages": [
+                {
+                    "url": "nfs://192.168.22.1:/data/storage/secondary/MCCT-SHARED-1",
+                    "provider" : "NFS"
+                }
+            ]
+        }
+    ],
+    "dbSvr": {
+        "dbSvr": "192.168.22.61",
+        "passwd": "cloud",
+        "db": "cloud",
+        "port": 3306,
+        "user": "cloud"
+    },
+    "logger":
+        {
+            "LogFolderPath": "/tmp/"
+        },
+    "globalConfig": [
+        {
+            "name": "network.gc.wait",
+            "value": "60"
+        },
+        {
+            "name": "storage.cleanup.interval",
+            "value": "300"
+        },
+        {
+            "name": "vm.op.wait.interval",
+            "value": "5"
+        },
+        {
+            "name": "default.page.size",
+            "value": "500"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "60"
+        },
+        {
+            "name": "workers",
+            "value": "10"
+        },
+        {
+            "name": "account.cleanup.interval",
+            "value": "600"
+        },
+        {
+            "name": "guest.domain.suffix",
+            "value": "cloud"
+        },
+        {
+            "name": "expunge.delay",
+            "value": "60"
+        },
+        {
+            "name": "vm.allocation.algorithm",
+            "value": "random"
+        },
+        {
+            "name": "expunge.interval",
+            "value": "60"
+        },
+        {
+            "name": "expunge.workers",
+            "value": "3"
+        },
+        {
+            "name": "check.pod.cidrs",
+            "value": "true"
+        },
+        {
+            "name": "secstorage.allowed.internal.sites",
+            "value": "192.168.22.0/24"
+        },
+        {
+            "name": "direct.agent.load.size",
+            "value": "1000"
+        },
+        {
+            "name": "network.gc.interval",
+            "value": "10"
+        },
+        {
+            "name": "network.gc.wait",
+            "value": "10"
+        }
+    ],
+    "mgtSvr": [
+        {
+            "mgtSvrName": "cs1",
+            "mgtSvrIp": "192.168.22.61",
+            "passwd": "password",
+            "user": "root",
+            "port": 8096,
+            "hypervisor": "KVM",
+            "useHttps": "False",
+            "certCAPath":  "NA",
+            "certPath":  "NA"
+        }
+    ]
+}


### PR DESCRIPTION
The commit ef47d5b55d70f15516563e0b667ca1760f0ead20 extends kvm_local_deploy tp provision also the management server, IF BOTH:
- `mgtSvrName` is specified in the marvin config by name `cs[0-9]`, like:

```
...
"mgtSvr": [
        {
            "mgtSvrName": "cs1",
...
```

AND
- (by aproving commit 871d45068b9cd4e88f351decaa19364c3e214ddf ) a role `cs.conf` is present, in this case a symlink to `cloudstack-mgt-dev.conf`, along with a working example marving config of how this could work

**So "current" deploys (marvin config not having `mgtSvrName`) will remain the same (for now)**

Goal is to be able to simultaneous (threads) deploy multiples hypervisors **AND** management server, or even multiple management servers
