### PR TITLE
Limit number of retries in wait_template_ready script

### DIFF
--- a/helper_scripts/cosmic/wait_template_ready.py
+++ b/helper_scripts/cosmic/wait_template_ready.py
@@ -13,17 +13,19 @@ class Templates():
 
     def __init__(self, argv):
         self.target = None
-        self.handleArguments(argv)
+        self.retries = 100
+        self.handle_arguments(argv)
 
     # Handle the arguments
-    def handleArguments(self, argv):
+    def handle_arguments(self, argv):
         # Usage message
         help = "Usage: ./" + os.path.basename(__file__) + " [options]" + \
-            "\n  --target -t \t\tManagement Server host (default 'localhost')"
+            "\n  --target -t \t\tManagement Server host (default 'localhost')" + \
+            "\n  --retries -r \t\tNumber of retries (default 100)"
 
         try:
             opts, args = getopt.getopt(
-                argv, "ht:", ["target="])
+                argv, "ht:r:", ["target=", "retries="])
         except getopt.GetoptError as e:
             print "Error: " + str(e)
             print help
@@ -36,42 +38,62 @@ class Templates():
                 sys.exit()
             elif opt in ("-t", "--target"):
                 self.target = arg
+            elif opt in ("-r", "--retries"):
+                self.retries = arg
 
         if self.target is None:
             self.target = "localhost"
 
     def list_templates(self):
         url = "http://" + self.target + ":8096/client/api?command=listTemplates&templatefilter=all&response=json"
-        print url
-        response = urllib2.urlopen(url)
-        return response.read()
+        print "Connecting to url %s" % url
+        try:
+            response = urllib2.urlopen(url)
+            return response.read()
+        except:
+            print "Problem connecting to %s" % url
+            return False
 
     def print_templates(self):
         templates = self.list_templates()
-        print templates
+        if templates:
+            print templates
 
     def get_json(self):
         templates = self.list_templates()
-        data = json.loads(templates)['listtemplatesresponse']['template']
-        return data
+        try:
+            data = json.loads(templates)['listtemplatesresponse']['template']
+            return data
+        except:
+            return False
 
     def templates_ready(self):
         templates = self.get_json()
+        if not templates:
+            return False
         for t in templates:
             if t is None:
                 continue
             if t['isready'] != True:
-                print time.strftime("%c") + " At least template '" + t['name'] + "' is not Ready"
+                print time.strftime("%c") + " At least template '" + t['name'] + "' is not ready, trying again soon.."
                 return False
         return True
 
     def wait_ready(self):
+        tries = 1
+        print "Attempt %s/%s" % (tries, self.retries)
         while True:
-            if self.templates_ready() == True:
+            if self.templates_ready():
                 print time.strftime("%c") + " All templates are ready!"
                 return True
-            else:
-                time.sleep(15)
+
+            tries += 1
+            if tries > int(self.retries):
+                print "ERROR: After %s retries still no ready templates. Aborting." % self.retries
+                sys.exit(1)
+
+            print "Sleeping 15s.."
+            time.sleep(15)
 
 t = Templates(sys.argv[1:])
 print t.wait_ready()


### PR DESCRIPTION
Now fails after `100` times, or use `-r` to specify retry count.

This prevents "hanging" builds, when something went wrong (like deploy of SSVM). Now we will sooner notice the failure.

Success:

```
rbergsma@mct-rbergsma01:/data/git/MCCT-SHARED-1/cosmic$ python /data/shared/helper_scripts/cosmic/wait_template_ready.py -t cs1 -r 3
processing option -t arg cs1
processing option -r arg 3
Attempt 1/3
Connecting to url http://cs1:8096/client/api?command=listTemplates&templatefilter=all&response=json
Sat Oct  1 18:38:36 2016 All templates are ready!
True
```

`echo $?`  

```
0
```

Failure (cannot connect):

```
rbergsma@mct-rbergsma01:/data/git/MCCT-SHARED-1/cosmic$ python /data/shared/helper_scripts/cosmic/wait_template_ready.py -t cs2 -r 3
processing option -t arg cs2
processing option -r arg 3
Attempt 1/3
Connecting to url http://cs2:8096/client/api?command=listTemplates&templatefilter=all&response=json
Problem connecting to http://cs2:8096/client/api?command=listTemplates&templatefilter=all&response=json
Sleeping 15s..
Connecting to url http://cs2:8096/client/api?command=listTemplates&templatefilter=all&response=json
Problem connecting to http://cs2:8096/client/api?command=listTemplates&templatefilter=all&response=json
Sleeping 15s..
Connecting to url http://cs2:8096/client/api?command=listTemplates&templatefilter=all&response=json
Problem connecting to http://cs2:8096/client/api?command=listTemplates&templatefilter=all&response=json
ERROR: After 3 retries still no ready templates. Aborting.
```

`echo $?`  

```
1
```
