### PR TITLE
Set variable to ci scripts (for copying file from there)

### DIFF
--- a/helper_scripts/cosmic/build_run_deploy.sh
+++ b/helper_scripts/cosmic/build_run_deploy.sh
@@ -17,6 +17,9 @@
 # Source the helper functions
 . `dirname $0`/helperlib.sh
 
+# Reference to ci scripts
+scripts_dir="$(dirname $0)/../../ci"
+
 
 function maven_build {
   build_dir=$1


### PR DESCRIPTION
This fixes the option to do only maven compile and war deploy (`-a`).
