### PR TITLE
This brings OVS 2.6.2 with STT to the Bubbles

### DIFF
--- a/ci/ci-deploy-data-center.sh
+++ b/ci/ci-deploy-data-center.sh
@@ -52,6 +52,7 @@ function add_nsx_connectivy_to_offerings {
 
   mysql -h ${csip} -u cloud -pcloud cloud -e "INSERT INTO cloud.ntwk_offering_service_map (network_offering_id, service, provider, created) (SELECT DISTINCT X.network_offering_id, 'Connectivity', 'NiciraNvp', X.created FROM cloud.ntwk_offering_service_map X);"
   mysql -h ${csip} -u cloud -pcloud cloud -e "INSERT INTO cloud.vpc_offering_service_map (vpc_offering_id, service, provider, created) (SELECT DISTINCT X.vpc_offering_id, 'Connectivity', 'NiciraNvp', X.created FROM cloud.vpc_offering_service_map X);"
+  mysql -h ${csip} -u cloud -pcloud cloud -e "INSERT INTO cloud.ntwk_offering_service_map (network_offering_id, service, provider, created) (SELECT DISTINCT X.id, 'Connectivity', 'NiciraNvp', X.created FROM cloud.network_offerings X WHERE name = 'System-Private-Gateway-Network-Offering');"
 }
 
 function add_nsx_controller_to_cosmic {

--- a/ci/ci-deploy-data-center.sh
+++ b/ci/ci-deploy-data-center.sh
@@ -54,6 +54,10 @@ function add_nsx_connectivy_to_offerings {
   mysql -h ${csip} -u cloud -pcloud cloud -e "INSERT INTO cloud.vpc_offering_service_map (vpc_offering_id, service, provider, created) (SELECT DISTINCT X.vpc_offering_id, 'Connectivity', 'NiciraNvp', X.created FROM cloud.vpc_offering_service_map X);"
 }
 
+function add_nsx_controller_to_cosmic {
+  bash -x /tmp/nsx_cosmic.sh
+}
+
 # Options
 while getopts ':m:' OPTION
 do
@@ -99,6 +103,7 @@ deploy_data_center ${marvin_configCopy}
 
 if  [ ! -v $( eval "echo \${nsx_controller_node_ip1}" ) ]; then
   add_nsx_connectivy_to_offerings ${cs1ip}
+  add_nsx_controller_to_cosmic
 fi
 
 wait_for_systemvm_templates ${cs1ip}

--- a/ci/ci-setup-infra.sh
+++ b/ci/ci-setup-infra.sh
@@ -264,6 +264,27 @@ function create_nsx_cluster {
   done
 }
 
+function setup_nsx_cosmic {
+
+  say "Generating script for setting up NSX controller in Cosmic"
+  echo "next_host_id=\$(mysql -h ${csip} -u cloud -pcloud cloud -e \"SELECT MAX(id) +1 FROM host;\" -s)" > /tmp/nsx_cosmic.sh
+  echo "nsx_cosmic_uuid=$(uuidgen)" >> /tmp/nsx_cosmic.sh
+  echo "nsx_cosmic_controller_uuid=$(uuidgen)" >> /tmp/nsx_cosmic.sh
+  echo "nsx_cosmic_controller_guid=$(uuidgen)" >> /tmp/nsx_cosmic.sh
+  echo "nsx_transzone_uuid=${nsx_transport_zone_uuid}" >> /tmp/nsx_cosmic.sh
+
+  echo "nsx_query1=\"INSERT INTO host (id, name, uuid, status, type, private_ip_address, private_netmask, private_mac_address, storage_ip_address, storage_netmask, storage_mac_address, storage_ip_address_2, storage_mac_address_2, storage_netmask_2, cluster_id, public_ip_address, public_netmask, public_mac_address, proxy_port, data_center_id, pod_id, cpu_sockets, cpus, speed, url, fs_type, hypervisor_type, hypervisor_version, ram, resource, version, parent, total_size, capabilities, guid, available, setup, dom0_memory, last_ping, mgmt_server_id, disconnected, created, removed, update_count, resource_state, owner, lastUpdated, engine_state) VALUES	(\${next_host_id}, 'Nicira Controller - 192.168.22.83', '\${nsx_cosmic_controller_uuid}', 'Down', 'L2Networking', '', NULL, NULL, '', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 'com.cloud.network.resource.NiciraNvpResource', '5.2.0.1-SNAPSHOT', NULL, NULL, NULL, '\${nsx_cosmic_controller_guid}', 1, 0, 0, 0, NULL, NULL, NOW(), NULL, 0, 'Enabled', NULL, NULL, 'Disabled');\" " >> /tmp/nsx_cosmic.sh
+  echo "mysql -h ${csip} -u cloud -pcloud cloud -e \"\${nsx_query1}\"" >> /tmp/nsx_cosmic.sh
+
+  echo "nsx_query2=\"INSERT INTO external_nicira_nvp_devices (uuid, physical_network_id, provider_name, device_name, host_id) VALUES ('\${nsx_cosmic_controller_uuid}', 201, 'NiciraNvp', 'NiciraNvp', \${next_host_id});\"" >> /tmp/nsx_cosmic.sh
+  echo "mysql -h ${csip} -u cloud -pcloud cloud -e \"\${nsx_query2}\"" >> /tmp/nsx_cosmic.sh
+
+  echo "nsx_query3=\"INSERT INTO host_details (host_id, name, value) VALUES (\${next_host_id}, 'transportzoneuuid', '\${nsx_transzone_uuid}'), (\${next_host_id}, 'physicalNetworkId', '201'), (\${next_host_id}, 'adminuser', 'admin'), (\${next_host_id}, 'ip', '192.168.22.83'), (\${next_host_id}, 'name', 'Nicira Controller - 192.168.22.83'), (\${next_host_id}, 'transportzoneisotype', 'stt'), (\${next_host_id}, 'guid', '\${nsx_cosmic_controller_guid}'),(\${next_host_id}, 'zoneId', '1'), (\${next_host_id}, 'adminpass', 'admin'),(\${next_host_id}, 'niciranvpdeviceid', '1');\"" >> /tmp/nsx_cosmic.sh
+  echo "mysql -h ${csip} -u cloud -pcloud cloud -e \"\${nsx_query3}\"" >> /tmp/nsx_cosmic.sh
+
+  echo "rm /tmp/nsx_cosmic.sh" >> /tmp/nsx_cosmic.sh
+}
+
 function configure_nsx_controller_node {
   nsx_master_controller_node_ip=$(getent hosts $1 | awk '{ print $1 }')
   nsx_controller_node_ip=$(getent hosts $2 | awk '{ print $1 }')
@@ -462,3 +483,7 @@ for i in 1 2 3 4 5 6 7 8 9; do
     fi
   fi
 done
+
+if  [ ! -v $( eval "echo \${nsx_controller_node_ip1}" ) ]; then
+  setup_nsx_cosmic
+fi

--- a/deploy/default/firstboot/centos7-kvm-ovs.sh
+++ b/deploy/default/firstboot/centos7-kvm-ovs.sh
@@ -54,36 +54,40 @@ sed -i -e 's/\#vnc_listen.*$/vnc_listen = "0.0.0.0"/g' /etc/libvirt/qemu.conf
 ### OVS ###
 ADM_IP=
 # Test to see if we have the internal mctadm1 box available
-#ping -c1 mctadm1 >/dev/null 2>&1
-#if [ $? -eq 0 ]; then
-#  ADM_IP='mctadm1'
-#fi
+ping -c1 mctadm1 >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  ADM_IP='mctadm1'
+fi
 
 ## Check if 192.168.31.41 is available.
-#ping -c1 192.168.31.41 >/dev/null 2>&1
-#if [ $? -eq 0 ]; then
-#  ADM_IP='192.168.31.41'
-#fi
+ping -c1 192.168.31.41 >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  ADM_IP='192.168.31.41'
+fi
 
 # If mctadm1 is available, get OVS packages from it
-#if [ ! -v $( eval "echo \${ADM_IP}" ) ]
-#  then
-#  echo "Detected we have an internal server to get OVS packages from."
-#  # Custom 2.5.1
-#  mv "/lib/modules/$(uname -r)/kernel/net/openvswitch/openvswitch.ko" "/lib/modules/$(uname -r)/kernel/net/openvswitch/openvswitch.org"
-#  yum -y install "kernel-devel-$(uname -r)"
-#  yum -y install http://${ADM_IP}/openvswitch/openvswitch-dkms-2.5.1-1.el7.centos.x86_64.rpm
-#  yum -y install http://${ADM_IP}/openvswitch/openvswitch-2.5.1-1.el7.centos.x86_64.rpm
-## If not, fall back to community sources
-#else
-
-echo "Installing OVS from community sources."
-# Comunity 2.4.x
-yum install -y yum-utils
-yum-config-manager --enablerepo=extras
-yum install -y centos-release-openstack-mitaka
-yum install -y openvswitch
-#fi
+if [ ! -v $( eval "echo \${ADM_IP}" ) ]
+then
+    echo "Detected we have an internal server to get OVS packages from."
+    # Custom 2.6.2 with STT
+    mv "/lib/modules/$(uname -r)/kernel/net/openvswitch/openvswitch.ko" "/lib/modules/$(uname -r)/kernel/net/openvswitch/openvswitch.org"
+    yum -y install "kernel-devel-$(uname -r)"
+    yum install -y dkms
+    sed -i -e 's/srcversion:/srcversion.disabled:/' /usr/sbin/dkms
+    yum -y install http://${ADM_IP}/openvswitch/openvswitch-dkms-2.6.2-1.el7.centos.x86_64.rpm
+    yum -y install http://${ADM_IP}/openvswitch/openvswitch-2.6.2-1.el7.centos.x86_64.rpm
+    dkms uninstall openvswitch/2.6.2
+    dkms autoinstall openvswitch/2.6.2
+    dkms status
+# If not, fall back to community sources
+else
+    echo "Installing OVS from community sources."
+    # Comunity 2.4.x
+    yum install -y yum-utils
+    yum-config-manager --enablerepo=extras
+    yum install -y centos-release-openstack-mitaka
+    yum install -y openvswitch
+fi
 
 # Start and enable OVS
 systemctl enable openvswitch

--- a/deploy/default/firstboot/centos7-kvm-ovs.sh
+++ b/deploy/default/firstboot/centos7-kvm-ovs.sh
@@ -9,12 +9,6 @@ sed -i 's/#baseurl/baseurl/' /etc/yum.repos.d/*.repo
 # Bring the second nic down to avoid routing problems
 ip link set dev eth1 down
 
-### Settings ####
-VLANPUB=50
-
-# Bubble NSX Ctrl
-NSXMANAGER="192.168.22.83"
-
 # Disable selinux (for now...)
 setenforce permissive
 sed -i "/SELINUX=enforcing/c\SELINUX=permissive" /etc/selinux/config
@@ -93,97 +87,15 @@ fi
 systemctl enable openvswitch
 systemctl start openvswitch
 
-# Bridges
-echo "Creating bridge cloudbr0.."
-ovs-vsctl add-br cloudbr0
-ovs-vsctl add-br cloud0
+# Execute OVS commands on reboot
+cat /data/shared/deploy/default/firstboot/configure_ovs.sh >> /etc/rc.d/rc.local
+echo "chmod 644 /etc/rc.d/rc.local" >> /etc/rc.d/rc.local
+echo "sync; sleep1" >> /etc/rc.d/rc.local
+echo "echo b > /proc/sysrq-trigger" >> /etc/rc.d/rc.local
 
-# Get interfaces
-IFACES=$(ls /sys/class/net | grep -E '^em|^eno|^eth|^p2' | tr '\n' ' ')
+# Run this once
+chmod 755  /etc/rc.d/rc.local
 
-# Create Bond with them
-echo "Creating bond with $IFACES"
-ovs-vsctl add-bond cloudbr0 bond0 $IFACES
-
-# Integration bridge
-echo "Creating NVP integration bridge br-int"
-ovs-vsctl -- --may-exist add-br br-int\
-            -- br-set-external-id br-int bridge-id br-int\
-            -- set bridge br-int other-config:disable-in-band=true\
-            -- set bridge br-int fail-mode=secure
-
-# Fake bridges
-echo "Create fake bridges"
-ovs-vsctl -- add-br trans0 cloudbr0
-ovs-vsctl -- add-br pub0 cloudbr0 $VLANPUB
-
-# Network configs
-BRMAC=$(cat /sys/class/net/$(ls /sys/class/net | grep -E '^em|^eno|^eth|^p2' | tr '\n' ' ' | awk {'print $1'})/address)
-
-# Physical interfaces
-for i in $IFACES
-  do echo "Configuring $i..."
-  echo "DEVICE=$i
-ONBOOT=yes
-NETBOOT=yes
-IPV6INIT=no
-BOOTPROTO=none
-NM_CONTROLLED=no
-" > /etc/sysconfig/network-scripts/ifcfg-$i
-done
-
-# Config cloudbr0
-echo "Configuring cloudbr0"
-echo "DEVICE=\"cloudbr0\"
-ONBOOT=yes
-DEVICETYPE=ovs
-TYPE=OVSBridge
-BOOTPROTO=dhcp
-HOTPLUG=no
-MACADDR=$BRMAC
-" > /etc/sysconfig/network-scripts/ifcfg-cloudbr0
-
-# Config cloud0
-echo "Configuring cloud0"
-echo "DEVICE=\"cloud0\"
-ONBOOT=yes
-DEVICETYPE=ovs
-TYPE=OVSBridge
-IPADDR=169.254.0.1
-NETMASK=255.255.0.0
-BOOTPROTO=static
-HOTPLUG=no
-" > /etc/sysconfig/network-scripts/ifcfg-cloud0
-
-# Config trans0
-echo "Configuring trans0"
-echo "DEVICE=\"trans0\"
-ONBOOT=yes
-DEVICETYPE=ovs
-TYPE=OVSIntPort
-BOOTPROTO=dhcp
-HOTPLUG=no
-#MACADDR=$BRMAC
-" > /etc/sysconfig/network-scripts/ifcfg-trans0
-
-# Config bond0
-echo "Configuring bond0"
-echo "DEVICE=\"bond0\"
-ONBOOT=yes
-DEVICETYPE=ovs
-TYPE=OVSBond
-OVS_BRIDGE=cloudbr0
-BOOTPROTO=none
-BOND_IFACES=\"$IFACES\"
-#OVS_OPTIONS="bond_mode=balance-tcp lacp=active other_config:lacp-time=fast"
-HOTPLUG=no
-" > /etc/sysconfig/network-scripts/ifcfg-bond0
-
-# NSX
-echo "Point manager to NSX controller"
-ovs-vsctl set-manager ssl:$NSXMANAGER:6632
-
-### End OVS ###
 ifup cloudbr0
 
 timedatectl set-timezone CET

--- a/deploy/default/firstboot/configure_ovs.sh
+++ b/deploy/default/firstboot/configure_ovs.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Bubble NSX Ctrl
+NSXMANAGER="192.168.22.83"
+
+# PUBLIC VLAN
+VLANPUB=50
+
+# Bridges
+echo "Creating bridge cloudbr0.."
+ovs-vsctl add-br cloudbr0
+ovs-vsctl add-br cloud0
+
+# Get interfaces
+IFACES=$(ls /sys/class/net | grep -E '^em|^eno|^eth|^p2' | tr '\n' ' ')
+
+# Create Bond with them
+echo "Creating bond with $IFACES"
+ovs-vsctl add-bond cloudbr0 bond0 $IFACES
+
+# Integration bridge
+echo "Creating NVP integration bridge br-int"
+ovs-vsctl -- --may-exist add-br br-int\
+            -- br-set-external-id br-int bridge-id br-int\
+            -- set bridge br-int other-config:disable-in-band=true\
+            -- set bridge br-int fail-mode=secure
+
+# Fake bridges
+echo "Create fake bridges"
+ovs-vsctl -- add-br trans0 cloudbr0
+ovs-vsctl -- add-br pub0 cloudbr0 $VLANPUB
+
+# Network configs
+BRMAC=$(cat /sys/class/net/$(ls /sys/class/net | grep -E '^em|^eno|^eth|^p2' | tr '\n' ' ' | awk {'print $1'})/address)
+
+# Physical interfaces
+for i in $IFACES
+  do echo "Configuring $i..."
+  echo "DEVICE=$i
+ONBOOT=yes
+NETBOOT=yes
+IPV6INIT=no
+BOOTPROTO=none
+NM_CONTROLLED=no
+" > /etc/sysconfig/network-scripts/ifcfg-$i
+done
+
+# Config cloudbr0
+echo "Configuring cloudbr0"
+echo "DEVICE=\"cloudbr0\"
+ONBOOT=yes
+DEVICETYPE=ovs
+TYPE=OVSBridge
+BOOTPROTO=dhcp
+HOTPLUG=no
+MACADDR=$BRMAC
+" > /etc/sysconfig/network-scripts/ifcfg-cloudbr0
+
+# Config cloud0
+echo "Configuring cloud0"
+echo "DEVICE=\"cloud0\"
+ONBOOT=yes
+DEVICETYPE=ovs
+TYPE=OVSBridge
+IPADDR=169.254.0.1
+NETMASK=255.255.0.0
+BOOTPROTO=static
+HOTPLUG=no
+" > /etc/sysconfig/network-scripts/ifcfg-cloud0
+
+# Config trans0
+echo "Configuring trans0"
+echo "DEVICE=\"trans0\"
+ONBOOT=yes
+DEVICETYPE=ovs
+TYPE=OVSIntPort
+BOOTPROTO=dhcp
+HOTPLUG=no
+#MACADDR=$BRMAC
+" > /etc/sysconfig/network-scripts/ifcfg-trans0
+
+# Config bond0
+echo "Configuring bond0"
+echo "DEVICE=\"bond0\"
+ONBOOT=yes
+DEVICETYPE=ovs
+TYPE=OVSBond
+OVS_BRIDGE=cloudbr0
+BOOTPROTO=none
+BOND_IFACES=\"$IFACES\"
+#OVS_OPTIONS="bond_mode=balance-tcp lacp=active other_config:lacp-time=fast"
+HOTPLUG=no
+" > /etc/sysconfig/network-scripts/ifcfg-bond0
+
+# NSX
+echo "Point manager to NSX controller"
+ovs-vsctl set-manager ssl:$NSXMANAGER:6632
+
+### End OVS ###
+


### PR DESCRIPTION
This allows a fully automatic setup of NSX powered bubble with the new OVS 2.6.2 which is STT enabled.

The final missing part was adding the NSX controller to Cosmic after the deployment. Now if you run this: `/data/shared/helper_scripts/cosmic/build_run_deploy.sh -m /data/shared/marvin/mct-zone1-cs1-kvm1-kvm2-NSX.cfg` you get a fully working setup that you can login to, spin a `VPC` and some `VMs` and have connectivity out-of-the-box.

Should you want to browse the NSX UI, you need to manually go to http://nsxmgr1 and add the control cluster. No way to do that automatically now. It's optional, it works just fine without it.

Ping @borisroman this is ready now