### PR TITLE
Make script continue on error and handle those instead of silent exit

### DIFF
--- a/ci/ci-setup-infra.sh
+++ b/ci/ci-setup-infra.sh
@@ -3,7 +3,7 @@
 scripts_dir=$(dirname $0)
 . ${scripts_dir}/../helper_scripts/cosmic/helperlib.sh
 
-set -e
+set -x
 
 function usage {
   printf "Usage: %s: -m marvin_config \n" $(basename $0) >&2
@@ -335,15 +335,19 @@ function authenticate_nsx {
   say "Authenticating against NSX controller"
   curl -L -k -c ${nsx_cookie} -X POST -d "username=${nsx_user}&password=${nsx_pass}" https://${nsx_master_controller_node_ip}/ws.v1/login
 
-  nsx_master_controller_node_ip_new=
-  nsx_master_controller_node_ip_new=$(curl -L -sD - -k -b ${nsx_cookie}  https://${nsx_master_controller_node_ip}/ws.v1/control-cluster | egrep 'HTTP/1.1 301|Location' | grep 'Location' | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}')
+  is_still_master=$(curl -L -sD - -k -b ${nsx_cookie}  https://${nsx_master_controller_node_ip}/ws.v1/control-cluster | egrep 'HTTP/1.1 200')
+  if [ $? -gt 0 ]; then
+     echo "Not master, look for the new one"
+      nsx_master_controller_node_ip_new=$(curl -L -sD - -k -b ${nsx_cookie}  https://${nsx_master_controller_node_ip}/ws.v1/control-cluster | egrep 'HTTP/1.1 301|Location' | grep 'Location' | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}')
 
-  if [ ! -v "${nsx_master_controller_node_ip_new}" ]; then
-    curl -L -k -c ${nsx_cookie} -X POST -d "username=${nsx_user}&password=${nsx_pass}" https://${nsx_master_controller_node_ip_new}/ws.v1/login
-    echo "New master ip ${nsx_master_controller_node_ip_new}"
-    echo "Old master ip ${nsx_master_controller_node_ip}"
-
-    export nsx_master_controller_node_ip=${nsx_master_controller_node_ip_new}
+      if [ ! -v "${nsx_master_controller_node_ip_new}" ]; then
+        curl -L -k -c ${nsx_cookie} -X POST -d "username=${nsx_user}&password=${nsx_pass}" https://${nsx_master_controller_node_ip_new}/ws.v1/login
+        echo "New master ip ${nsx_master_controller_node_ip_new}"
+        echo "Old master ip ${nsx_master_controller_node_ip}"
+        export nsx_master_controller_node_ip=${nsx_master_controller_node_ip_new}
+      fi
+  else
+    export nsx_master_controller_node_ip=${nsx_master_controller_node_ip}
   fi
 }
 


### PR DESCRIPTION
When `old_master == new_master` this exits with non zero: `egrep 'HTTP/1.1 301|Location' (it is 200)` so nothing really went wrong. Now the script will handle it and continue.