### PR TITLE
Make the CloudStackOps install go smooth again

### DIFF
--- a/helper_scripts/cosmic/setup_cloudstackOps.sh
+++ b/helper_scripts/cosmic/setup_cloudstackOps.sh
@@ -19,6 +19,12 @@ if [ ! -d "${BASEDIR}/python_cloud" ]; then
   virtualenv ${BASEDIR}/python_cloud
   source ${BASEDIR}/python_cloud/bin/activate
   pip install --extra-index-url https://pypi.python.org/pypi/mysql-connector-python/2.0.4 mysql-connector-python
+  pip install slackweb
+  pip install six
+  pip install packaging
+  pip install setuptools
+  pip install appdirs
+  pip install fabric
   pip install ${BASEDIR}/cloudstackOps/marvin/Marvin-0.1.0.tar.gz
   pip install prettytable clint
   pip install fabric


### PR DESCRIPTION
Run script to install CloudStackOps toolbox. Worked before, now needed some love. Easy for testing stuff.

```
# Run script
helper_scripts/cosmic/setup_cloudstackOps.sh

# Source virtual env
source /data/git/cs1/python_cloud/bin/activate

# Go to scripts
cd /data/git/cs1/cloudstackOps

# Run them
(python_cloud)[root@cs1 cloudstackOps]#  python listVirtualMachines.py -o MCCT-KVM-1
Welcome to CloudStackOps
Warning: No Slack integration found, so not using. See config file to setup.
Note: Trying to use API credentials from CloudMonkey profile 'config'
Note: Trying to use API credentials from local config profile 'config'
Note: Connected to 'http://cs1.cloud.lan:8080/client/api'

+-------------------------+---------+----------------+------------------+--------+-------+----------+------+--------+---------+--------------------------+
| VM                      | Storage |    Template    | Router nic count | Memory | Cores | Instance | Host | Domain | Account |         Created          |
+-------------------------+---------+----------------+------------------+--------+-------+----------+------+--------+---------+--------------------------+
| VM-1eaa658f-18a3-404..  |   0 GB  | tiny linux kvm |        -         |  0 GB  |   1   | i-2-4-VM | kvm1 |  ROOT  |  admin  | 2017-02-10T20:57:30+0100 |
| vpc1 (vpc) [ReqUpdate!] |    -    |       -        |     2 nics       | 256 MB |   1   |  r-3-VM  | kvm1 |  ROOT  |  admin  | 2017-02-10T20:57:12+0100 |
+-------------------------+---------+----------------+------------------+--------+-------+----------+------+--------+---------+--------------------------+

Summary 'MCCT-KVM-1':
 Total number of VMs: 2
 Total number hypervisors: 2
 Total allocated RAM: 0.25 / 12 GB (2.08 %)
 Total allocated cores: 2
 Total allocated storage: 0 GB
```