### PR TITLE
Switch the default isolation method to VXLAN for NSX

### DIFF
--- a/ci/ci-setup-infra.sh
+++ b/ci/ci-setup-infra.sh
@@ -264,7 +264,7 @@ function setup_nsx_cosmic {
   echo "nsx_query2=\"INSERT INTO external_nicira_nvp_devices (uuid, physical_network_id, provider_name, device_name, host_id) VALUES ('\${nsx_cosmic_controller_uuid}', 201, 'NiciraNvp', 'NiciraNvp', \${next_host_id});\"" >> /tmp/nsx_cosmic.sh
   echo "mysql -h ${csip} -u cloud -pcloud cloud -e \"\${nsx_query2}\"" >> /tmp/nsx_cosmic.sh
 
-  echo "nsx_query3=\"INSERT INTO host_details (host_id, name, value) VALUES (\${next_host_id}, 'transportzoneuuid', '\${nsx_transzone_uuid}'), (\${next_host_id}, 'physicalNetworkId', '201'), (\${next_host_id}, 'adminuser', 'admin'), (\${next_host_id}, 'ip', '192.168.22.83'), (\${next_host_id}, 'name', 'Nicira Controller - 192.168.22.83'), (\${next_host_id}, 'transportzoneisotype', 'stt'), (\${next_host_id}, 'guid', '\${nsx_cosmic_controller_guid}'),(\${next_host_id}, 'zoneId', '1'), (\${next_host_id}, 'adminpass', 'admin'),(\${next_host_id}, 'niciranvpdeviceid', '1');\"" >> /tmp/nsx_cosmic.sh
+  echo "nsx_query3=\"INSERT INTO host_details (host_id, name, value) VALUES (\${next_host_id}, 'transportzoneuuid', '\${nsx_transzone_uuid}'), (\${next_host_id}, 'physicalNetworkId', '201'), (\${next_host_id}, 'adminuser', 'admin'), (\${next_host_id}, 'ip', '192.168.22.83'), (\${next_host_id}, 'name', 'Nicira Controller - 192.168.22.83'), (\${next_host_id}, 'transportzoneisotype', 'vxlan'), (\${next_host_id}, 'guid', '\${nsx_cosmic_controller_guid}'),(\${next_host_id}, 'zoneId', '1'), (\${next_host_id}, 'adminpass', 'admin'),(\${next_host_id}, 'niciranvpdeviceid', '1');\"" >> /tmp/nsx_cosmic.sh
   echo "mysql -h ${csip} -u cloud -pcloud cloud -e \"\${nsx_query3}\"" >> /tmp/nsx_cosmic.sh
 
   echo "rm /tmp/nsx_cosmic.sh" >> /tmp/nsx_cosmic.sh
@@ -304,7 +304,7 @@ function configure_nsx_service_node {
     "transport_connectors": [
         {
             "ip_address": "'"${nsx_service_node_ip}"'",
-            "type": "STTConnector",
+            "type": "VXLANConnector",
             "transport_zone_uuid": "'"${nsx_transport_zone_uuid}"'"
         }
     ],
@@ -386,7 +386,7 @@ function configure_kvm_host_in_nsx {
         {
             "ip_address": "'"${kvm_host_ip}"'",
             "transport_zone_uuid": "'"${nsx_transport_zone_uuid}"'",
-            "type": "STTConnector"
+            "type": "VXLANConnector"
         }
     ]
 }' https://${nsx_master_controller_node_ip}/ws.v1/transport-node 2>&1 > /dev/null

--- a/deploy/default/post_deploy/nsx_cluster.sh
+++ b/deploy/default/post_deploy/nsx_cluster.sh
@@ -51,7 +51,7 @@ curl -k -b cookie.txt -X POST -d '{
     "transport_connectors": [
         {
             "ip_address": "'"${NSX_SERVICE_IP}"'",
-            "type": "STTConnector",
+            "type": "VXLANConnector",
             "transport_zone_uuid": "'"${transportZoneUuid}"'"
         }
     ],
@@ -76,7 +76,7 @@ curl -k -b cookie.txt -X POST -d '{
         {
             "ip_address": "'"${KVM_HOST_IP}"'",
             "transport_zone_uuid": "'"${transportZoneUuid}"'",
-            "type": "STTConnector"
+            "type": "VXLANConnector"
         }
     ]
 }' https://${NSX_CONTROLLER}/ws.v1/transport-node 2> /dev/null 1> transport-node-${KVM_HOST}.json

--- a/deploy/default/postboot/post_nsx_hypervisor.sh
+++ b/deploy/default/postboot/post_nsx_hypervisor.sh
@@ -47,7 +47,7 @@ curl -k -b cookie.txt -X POST -d '{
         {
             "ip_address": "'"${KVM_HOST_IP}"'",
             "transport_zone_uuid": "'"${transportZoneUuid}"'",
-            "type": "STTConnector"
+            "type": "VXLANConnector"
         }
     ]
 }' https://${NSX_CONTROLLER}/ws.v1/transport-node 2> /dev/null 1> transport-node-${KVM_HOST}.json


### PR DESCRIPTION
For the bubbles, it's way easier to use VXLAN rather than STT as we can use default community packages. The performance benefit of STT is not needed when testing in the bubbles. This PR switches NSX to use VXLAN as an isolation method. The hacks to use custom packages are removed.

This is a requirement for Jenkins slaves to use NSX by default (when the tests are made generic to handle this).

NSX transport nodes now have VXLAN connectors:
![image](https://cloud.githubusercontent.com/assets/1630096/22861191/efb87ffa-f112-11e6-80c0-52e88d5a71fb.png)

The hypervisors make VXLAN connections:
```
[root@kvm1 ~]# ovs-vsctl show
ee52912d-cf71-47fd-9cdf-ae529db377bf
    Manager "ssl:192.168.22.85:6632"
        is_connected: true
    Manager "ssl:192.168.22.83:6632"
        is_connected: true
    Manager "ssl:192.168.22.84:6632"
        is_connected: true
    Bridge "cloud0"
        Port "vnet0"
            Interface "vnet0"
        Port "vnet3"
            Interface "vnet3"
        Port "vnet6"
            Interface "vnet6"
        Port "cloud0"
            Interface "cloud0"
                type: internal
    Bridge "cloudbr0"
        Port "vnet4"
            Interface "vnet4"
        Port "vnet1"
            Interface "vnet1"
        Port "bond0"
            Interface "eth1"
            Interface "eth0"
        Port "vnet2"
            tag: 50
            Interface "vnet2"
        Port "cloudbr0"
            Interface "cloudbr0"
                type: internal
        Port "vnet5"
            tag: 50
            Interface "vnet5"
        Port "vnet7"
            tag: 50
            Interface "vnet7"
        Port "pub0"
            tag: 50
            Interface "pub0"
                type: internal
    Bridge br-int
        Controller "ssl:192.168.22.84:6633"
            is_connected: true
        Controller "unix:ovs-l3d-flow-stats.mgmt"
        Controller "unix:ovs-l3d.mgmt"
        Controller "ssl:192.168.22.83:6633"
            is_connected: true
        fail_mode: secure
        Port "vxlan3232241239"
            Interface "vxlan3232241239"
                type: vxlan
                options: {key=flow, remote_ip="192.168.22.87", tos=inherit}
        Port "vxlan3232241238"
            Interface "vxlan3232241238"
                type: vxlan
                options: {key=flow, remote_ip="192.168.22.86", tos=inherit}
        Port "vnet8"
            Interface "vnet8"
        Port "vnet10"
            Interface "vnet10"
        Port br-int
            Interface br-int
                type: internal
        Port "vnet9"
            Interface "vnet9"
        Port "vxlan3232241174"
            Interface "vxlan3232241174"
                type: vxlan
                options: {key=flow, remote_ip="192.168.22.22", tos=inherit}
    ovs_version: "2.6.1"
[root@kvm1 ~]# 
```

Connectivity over multiple hypervisors works fine:
```
[root@Macchinina ~]# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast qlen 1000
    link/ether 02:00:4c:34:00:01 brd ff:ff:ff:ff:ff:ff
    inet 10.2.1.88/24 brd 10.2.1.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::4cff:fe34:1/64 scope link 
       valid_lft forever preferred_lft forever
[root@Macchinina ~]# traceroute -I 10.1.1.111
traceroute to 10.1.1.111 (10.1.1.111), 30 hops max, 46 byte packets
 1  10.2.1.1 (10.2.1.1)  0.737 ms  0.616 ms  0.745 ms
 2  172.16.0.1 (172.16.0.1)  1.813 ms  0.947 ms  0.787 ms
 3  10.1.1.111 (10.1.1.111)  2.170 ms  1.651 ms  1.584 ms
[root@Macchinina ~]# 
```

KVM1:
```
[root@kvm1 ~]# virsh list
 Id    Name                           State
----------------------------------------------------
 1     s-1-VM                         running
 2     v-2-VM                         running
 3     r-4-VM                         running
 4     i-2-5-VM                       running
```

KVM2:
```
[root@kvm2 ~]# virsh list
 Id    Name                           State
----------------------------------------------------
 1     r-3-VM                         running
 2     i-2-6-VM                       running
```

Once PR #208 is merged, we can alter the Marvin configs to specify VXLAN rather than STT, but this is just a cosmetic change ;-)
