### PR TITLE
Revert "Break on error"

### DIFF
--- a/ci/ci-setup-infra.sh
+++ b/ci/ci-setup-infra.sh
@@ -3,7 +3,7 @@
 scripts_dir=$(dirname $0)
 . ${scripts_dir}/../helper_scripts/cosmic/helperlib.sh
 
-set -e
+set -x
 
 function usage {
   printf "Usage: %s: -m marvin_config -c to inform we're configuring CloudStack instead of Cosmic\n" $(basename $0) >&2


### PR DESCRIPTION
Reverts MissionCriticalCloud/bubble-toolkit#233

My mistake. PR https://github.com/MissionCriticalCloud/cosmic/pull/374 should be merged first.

Unfortunately it failed due to some instability. But this now prevents all other PR requests from succeeding (building in Jenkins).

Once 233 is merged, this one can be re-applied.