### PR TITLE
Add switch to make the (marvin) tests optional

### DIFF
--- a/helper_scripts/cosmic/helperlib.sh
+++ b/helper_scripts/cosmic/helperlib.sh
@@ -472,6 +472,11 @@ function marvin_build_and_install {
 
   # Marvin's root path
   build_dir=$1
+  if [ -z $2 ]; then
+    skip_tests="false";
+  else
+    skip_tests=$2;
+  fi;
 
   say "[MARVIN] Installing..."
 
@@ -489,9 +494,13 @@ function marvin_build_and_install {
   # Back to Marvin's root path
   cd "${build_dir}"
 
-  # Test Marvin
-  say "[MARVIN] Starting tests..."
-  nosetests -v --with-xunit tests
+  if [ "${skip_tests}" == "false" ]; then
+    # Test Marvin
+    say "[MARVIN] Starting tests..."
+    nosetests -v --with-xunit tests
+  else
+    say "[MARVIN] Skipping tests...";
+  fi
 
   # Create Marvin distribution package
   say "[MARVIN] Creating distribution package..."


### PR DESCRIPTION
Just to install marvin from source (without running tests):
```
# Source the helperlib
. /data/shared/helper_scripts/cosmic/helperlib.sh

# Execute marvin build and install, skipping tests
marvin_build_and_install /data/git/MCCT-SHARED-1/cosmic/cosmic-marvin true
```
Easy way of installing marvin when developping marvin, or when unit-tests are getting in the way
