### PR TITLE
Fix pip download url

### DIFF
--- a/deploy/cloudstack/firstboot/centos7-cloudstack-dev.sh
+++ b/deploy/cloudstack/firstboot/centos7-cloudstack-dev.sh
@@ -31,7 +31,7 @@ cd /root
 
 wget https://raw.githubusercontent.com/remibergsma/dotfiles/master/.screenrc
 
-curl "https://bootstrap.pypa.io/get-pip.py" | python
+curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" | python
 pip install cloudmonkey
 
 easy_install nose

--- a/deploy/default/firstboot/centos6-cloudstack-dev.sh
+++ b/deploy/default/firstboot/centos6-cloudstack-dev.sh
@@ -27,7 +27,7 @@ cd /root
 
 wget https://raw.githubusercontent.com/remibergsma/dotfiles/master/.screenrc
 
-curl "https://bootstrap.pypa.io/get-pip.py" | python
+curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" | python
 pip install mysql-connector-python --allow-external mysql-connector-python requests
 pip install cloudmonkey
 

--- a/deploy/default/firstboot/centos7-cloudstack-dev.sh
+++ b/deploy/default/firstboot/centos7-cloudstack-dev.sh
@@ -28,7 +28,7 @@ cd /root
 
 wget https://raw.githubusercontent.com/remibergsma/dotfiles/master/.screenrc
 
-curl "https://bootstrap.pypa.io/get-pip.py" | python
+curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" | python
 pip install cloudmonkey
 
 easy_install nose


### PR DESCRIPTION
Scripts are now failing with the error:
```ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/pip/2.7/get-pip.py instead.```